### PR TITLE
Fix Bundler plugin loading errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 Metrics/BlockLength:
   Exclude:
+    - '*.gemspec'
     - 'spec/**/*'
 
 Metrics/ClassLength:

--- a/bin/tf
+++ b/bin/tf
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-require 'bundler/setup' if File.exist? File.expand_path('../../Gemfile', __FILE__)
+require 'bundler/setup' if File.exist?(File.expand_path('../../Gemfile', __FILE__))
 require 'yle_tf/cli'
 
 cli = YleTf::CLI.new(ARGV)

--- a/lib/yle_tf/plugin/loader.rb
+++ b/lib/yle_tf/plugin/loader.rb
@@ -19,10 +19,10 @@ class YleTf
       end
 
       def self.load_bundler_plugins
-        if defined?(Bundler)
-          print_bundler_plugin_list if Logger.debug?
-          Bundler.require(BUNDLER_PLUGIN_GROUP)
-        end
+        return if !bundler_set_up?
+
+        Logger.debug { print_bundler_plugin_list }
+        Bundler.require(BUNDLER_PLUGIN_GROUP)
       end
 
       def self.load_user_plugins
@@ -45,6 +45,10 @@ class YleTf
 
       def self.user_plugins
         ENV.fetch('TF_PLUGINS', '').split(/[ ,]+/)
+      end
+
+      def self.bundler_set_up?
+        defined?(Bundler) && Bundler.respond_to?(:require)
       end
 
       def self.print_bundler_plugin_list

--- a/yle_tf.gemspec
+++ b/yle_tf.gemspec
@@ -23,9 +23,9 @@ Gem::Specification.new do |spec|
     'antti.forsell@iki.fi',
   ]
 
-  spec.files = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
-  end
+  spec.files = Dir['bin/**/*'] +
+               Dir['lib/**/*.rb'] +
+               Dir['vendor/**/*']
 
   spec.bindir        = 'bin'
   spec.executables   = ['tf']


### PR DESCRIPTION
Check that Bundler is really set up before loading plugins with it. Requiring 'bundler/setup' won't do much if the Gemfile is not found, leaving `Bundler.require` undefined.

Also exclude the Gemfile (and other non-ruby code) from the gem.