### PR TITLE
Colors for error and warning messages

### DIFF
--- a/lib/yle_tf/cli.rb
+++ b/lib/yle_tf/cli.rb
@@ -5,7 +5,7 @@ class YleTf
     attr_reader :tf_options, :tf_command, :tf_command_args, :tf_env
 
     # YleTf option arguments
-    TF_OPTIONS = %w[--debug --no-hooks --only-hooks].freeze
+    TF_OPTIONS = %w[--debug --no-color --no-hooks --only-hooks].freeze
 
     HELP_ARGS = %w[-h --help help].freeze
     VERSION_ARGS = %w[-v --version version].freeze
@@ -65,7 +65,8 @@ class YleTf
         @tf_env = 'error'
       end
 
-      self.debug = true if @tf_options.include?(:debug)
+      self.debug = true if @tf_options[:debug]
+      YleTf::Logger.color = !@tf_options[:no_color]
     end
 
     # Returns `Symbol` for the arg, e.g. `"--foo-bar"` -> `:foo_bar`

--- a/lib/yle_tf/logger.rb
+++ b/lib/yle_tf/logger.rb
@@ -1,6 +1,7 @@
 require 'forwardable'
 require 'logger'
 require 'rubygems'
+require 'yle_tf/logger/colorize'
 
 class YleTf
   # Logger for debug, error, etc. outputs.
@@ -28,11 +29,32 @@ class YleTf
 
     def self.log_formatter
       proc do |severity, _datetime, progname, msg|
+        msg = Colorize.colorize(msg, color(severity))
+
         if progname
           "[#{progname}] #{severity}: #{msg}\n"
         else
           "#{severity}: #{msg}\n"
         end
+      end
+    end
+
+    def self.color?
+      @color
+    end
+
+    def self.color=(value)
+      @color = value
+    end
+
+    def self.color(severity)
+      return if !color?
+
+      case severity.to_s
+      when 'FATAL', 'ERROR'
+        :red
+      when 'WARN'
+        :brown
       end
     end
 

--- a/lib/yle_tf/logger/colorize.rb
+++ b/lib/yle_tf/logger/colorize.rb
@@ -1,0 +1,22 @@
+class YleTf
+  module Logger
+    module Colorize
+      COLORS = {
+        black:   30,
+        red:     31,
+        brown:   33,
+        blue:    34,
+        magenta: 35,
+        cyan:    36,
+        gray:    37
+      }.freeze
+
+      # Wraps the message with the specified ANSI color code
+      # if the color is specified and supported
+      def self.colorize(msg, color)
+        code = COLORS[color]
+        code ? "\033[#{code}m#{msg}\033[0m" : msg
+      end
+    end
+  end
+end

--- a/lib/yle_tf_plugins/commands/__default/command.rb
+++ b/lib/yle_tf_plugins/commands/__default/command.rb
@@ -5,9 +5,15 @@ module YleTfPlugins
     class Command
       def execute(env)
         command = env[:tf_command]
-        args    = env[:tf_command_args]
+
+        args = env[:tf_command_args].dup
+        args << '-no-color' if !color?(env)
 
         YleTf::System.cmd('terraform', command, *args)
+      end
+
+      def color?(env)
+        !env[:tf_options][:no_color]
       end
     end
   end

--- a/lib/yle_tf_plugins/commands/help/command.rb
+++ b/lib/yle_tf_plugins/commands/help/command.rb
@@ -20,6 +20,7 @@ module YleTfPlugins
           o.on('-h', '--help', 'Prints this help')
           o.on('-v', '--version', 'Prints the version information')
           o.on('--debug', 'Print debug information')
+          o.on('--no-color', 'Do not output with colors')
           o.on('--no-hooks', 'Do not run any hooks')
           o.on('--only-hooks', 'Only run the hooks')
           o.separator ''


### PR DESCRIPTION
Output all kind of error messages in the `Logger` with colors by default.
Can be turned off with `--no-color`, which is also passed to the Terraform command.