### PR TITLE
Support for IO handlers for `System.cmd` commands, pipe most command and hook output to Logger

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+Metrics/AbcSize:
+  Max: 16
+
 Metrics/BlockLength:
   Exclude:
     - '*.gemspec'
@@ -11,7 +14,7 @@ Metrics/LineLength:
   Severity: warning
 
 Metrics/MethodLength:
-  Max: 12
+  Max: 13
   Severity: warning
 
 Style/Documentation:

--- a/lib/yle_tf/action/terraform_init.rb
+++ b/lib/yle_tf/action/terraform_init.rb
@@ -15,8 +15,8 @@ class YleTf
         config = env[:config]
         backend = backend_config(config)
 
-        Logger.debug('Initializing Terraform with backend configuration:')
-        Logger.debug(backend.to_s)
+        Logger.info('Initializing Terraform')
+        Logger.debug("Backend configuration: #{backend}")
 
         if VersionRequirement.pre_0_9?(env[:terraform_version])
           init_pre_0_9(backend)
@@ -29,17 +29,21 @@ class YleTf
 
       def init_pre_0_9(backend)
         cli_args = backend.cli_args
-        YleTf::System.cmd('terraform', 'remote', 'config', *cli_args) if cli_args
+        if cli_args
+          YleTf::System.cmd('terraform', 'remote', 'config',
+                            '-no-color', *cli_args,
+                            stdout: :debug)
+        end
 
         Logger.debug('Fetching Terraform modules')
-        YleTf::System.cmd('terraform', 'get')
+        YleTf::System.cmd('terraform', 'get', '-no-color', stdout: :debug)
       end
 
       def init(backend)
         Logger.debug('Generating the backend configuration')
         backend.generate_config do
           Logger.debug('Initializing Terraform')
-          YleTf::System.cmd('terraform', 'init', '-no-color')
+          YleTf::System.cmd('terraform', 'init', '-no-color', stdout: :debug)
         end
       end
 

--- a/lib/yle_tf/action/verify_terraform_version.rb
+++ b/lib/yle_tf/action/verify_terraform_version.rb
@@ -1,5 +1,6 @@
 require 'yle_tf/error'
 require 'yle_tf/logger'
+require 'yle_tf/system'
 require 'yle_tf/version_requirement'
 
 class YleTf
@@ -22,10 +23,8 @@ class YleTf
       end
 
       def terraform_version
-        # TODO: move `command` to YleTf::System
-        Regexp.last_match(1) if `terraform version` =~ /^Terraform v([^\s]+)/
-      rescue Errno::ENOENT
-        nil
+        v = YleTf::System.read_cmd('terraform', 'version', error_handler: proc {})
+        Regexp.last_match(1) if v =~ /^Terraform v([^\s]+)/
       end
 
       def verify_version(env)

--- a/lib/yle_tf/logger.rb
+++ b/lib/yle_tf/logger.rb
@@ -6,9 +6,11 @@ class YleTf
   # Logger for debug, error, etc. outputs.
   # Prints to STDERR, so it does not mess with e.g. `terraform output`.
   module Logger
+    LEVELS = %i[debug info warn error fatal].freeze
+
     class << self
       extend Forwardable
-      def_delegators :logger, :debug, :info, :warn, :error, :fatal
+      def_delegators :logger, *LEVELS
       def_delegators :logger, :debug?
     end
 
@@ -29,7 +31,7 @@ class YleTf
     def self.log_formatter
       proc do |severity, _datetime, progname, msg|
         if progname
-          "[#{progname}] #{severity}: #{msg}\n"
+          "#{severity}: [#{progname}] #{msg}\n"
         else
           "#{severity}: #{msg}\n"
         end

--- a/lib/yle_tf/system.rb
+++ b/lib/yle_tf/system.rb
@@ -1,22 +1,98 @@
+require 'English'
+require 'open3'
 require 'shellwords'
-
+require 'thwait'
 require 'yle_tf/error'
 require 'yle_tf/logger'
+require 'yle_tf/system/io_handlers'
 
 class YleTf
   # Helpers to execute system commands with error handling
-  #
-  # TODO: Add way to wrap stdout of the commands and direct it to `Logger`
   class System
     ExecuteError = Class.new(YleTf::Error)
 
-    def self.cmd(*args, **opts)
-      env = opts[:env]
-      YleTf::Logger.debug { "Calling `#{args.shelljoin}`#{" with env '#{env}'" if env}" }
+    DEFAULT_ERROR_HANDLER = ->(_exit_code, error) { raise error }.freeze
 
-      system(env || {}, *args) ||
-        raise(ExecuteError,
-              "Failed to execute `#{args.shelljoin}`#{" with env '#{env}'" if env}")
+    DEFAULT_IO_HANDLERS = {
+      stdin: :dev_null,
+      stdout: :info,
+      stderr: :error
+    }.freeze
+
+    def self.console_cmd(*args, **opts)
+      env = opts[:env] || {}
+
+      YleTf::Logger.debug { "Calling #{cmd_string(args, env)}" }
+
+      system(env, *args)
+      verify_exit_status($CHILD_STATUS, opts[:error_handler], cmd_string(args))
+    end
+
+    # Executes the command and attaches IO streams
+    def self.cmd(*args, **opts)
+      opts = DEFAULT_IO_HANDLERS.merge(opts)
+      env = opts[:env] || {}
+      progname = opts.fetch(:progname) { args.first }
+
+      YleTf::Logger.debug { "Calling #{cmd_string(args, env)}" }
+
+      status = Open3.popen3(env, *args, &handle_io(progname, opts))
+      verify_exit_status(status, opts[:error_handler], cmd_string(args))
+    rescue Interrupt, Errno::ENOENT => e
+      error(opts[:error_handler], "Failed to execute #{cmd_string(args)}: #{e}")
+    end
+
+    def self.read_cmd(*args, **opts)
+      buffer = StringIO.new
+      cmd(*args, opts.merge(stdout: buffer))
+      buffer.string
+    end
+
+    def self.cmd_string(args, env = nil)
+      "`#{args.shelljoin}`#{" with env '#{env}'" if env && !env.empty?}"
+    end
+
+    def self.handle_io(progname, handlers)
+      lambda do |stdin, stdout, stderr, wait_thr|
+        in_thr = attach_input_handler(handlers[:stdin], stdin, progname)
+        out_thr = [
+          attach_output_handler(handlers[:stdout], stdout, progname),
+          attach_output_handler(handlers[:stderr], stderr, progname)
+        ]
+
+        # Wait for the process to exit
+        wait_thr.value.tap do
+          YleTf::Logger.debug("`#{progname}` exited, killing input handler thread")
+          in_thr.kill if in_thr.is_a?(Thread)
+
+          YleTf::Logger.debug('Waiting for output handler threads to stop')
+          ThreadsWait.all_waits(out_thr)
+        end
+      end
+    end
+
+    def self.attach_input_handler(handler, io, progname)
+      io_proc = IOHandlers.input_handler(handler)
+      io_proc.call(io, progname)
+    end
+
+    def self.attach_output_handler(handler, io, progname)
+      io_proc = IOHandlers.output_handler(handler)
+      io_proc.call(io, progname)
+    end
+
+    def self.verify_exit_status(status, handler, cmd)
+      status.success? ||
+        error(handler,
+              "Failed to execute #{cmd} (#{status.exitstatus})",
+              status.exitstatus)
+    end
+
+    def self.error(handler, error_msg, exit_code = nil)
+      YleTf::Logger.debug(error_msg)
+
+      handler ||= DEFAULT_ERROR_HANDLER
+      handler.call(exit_code, ExecuteError.new(error_msg))
     end
   end
 end

--- a/lib/yle_tf/system/io_handlers.rb
+++ b/lib/yle_tf/system/io_handlers.rb
@@ -1,0 +1,105 @@
+require 'yle_tf/system/output_logger'
+
+class YleTf
+  class System
+    class IOHandlers
+      BLOCK_SIZE = 1024
+
+      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength
+      def self.input_handler(handler)
+        case handler
+        when :close
+          close
+        when :console
+          console_input
+        when :dev_null
+          dev_null_input
+        when IO, StringIO
+          io_input(handler)
+        else
+          if !handler.respond_to?(:call)
+            raise YleTf::Error, "Unknown input handler #{handler.inspect}"
+          end
+          handler
+        end
+      end
+
+      def self.output_handler(handler)
+        case handler
+        when :close
+          close
+        when :console
+          console_output
+        when :dev_null
+          dev_null_output
+        when IO, StringIO
+          io_output(handler)
+        when Symbol
+          OutputLogger.new(handler)
+        else
+          if !handler.respond_to?(:call)
+            raise YleTf::Error, "Unknown output handler #{handler.inspect}"
+          end
+          handler
+        end
+      end
+      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength
+
+      # Returns a lambda that just closes the IO
+      def self.close
+        ->(io, *) { io.close }
+      end
+
+      # Returns a lambda that pipes STDIN to the IO
+      def self.console_input
+        io_input(STDIN)
+      end
+
+      # Returns a lambda that pipes IO's output to STDOUT
+      def self.console_output
+        io_output(STDOUT)
+      end
+
+      # Returns a lambda that does nothing
+      def self.dev_null_input
+        ->(*) {}
+      end
+
+      # Returns a lambda that just consumes the IO's output
+      def self.dev_null_output
+        lambda do |io, *|
+          Thread.new do
+            while io.read; end
+          end
+        end
+      end
+
+      # Returns a lambda that pipes the source IO to the IO's input
+      def self.io_input(source)
+        lambda do |target, *|
+          Thread.new do
+            begin
+              while (data = source.readpartial(BLOCK_SIZE))
+                target.write(data)
+              end
+            ensure
+              target.close_write
+            end
+          end
+        end
+      end
+
+      # Returns a lambda that pipes IO's output to the target IO
+      # Does not close the target stream
+      def self.io_output(target)
+        lambda do |source, *|
+          Thread.new do
+            while (data = source.readpartial(BLOCK_SIZE))
+              target.write(data)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/yle_tf/system/output_logger.rb
+++ b/lib/yle_tf/system/output_logger.rb
@@ -1,0 +1,29 @@
+require 'yle_tf/logger'
+
+class YleTf
+  class System
+    class OutputLogger
+      attr_reader :level
+
+      def initialize(level)
+        @level = level.to_sym
+
+        raise YleTf::Error, "Unknown log level '#{@level}'" if !level?(@level)
+      end
+
+      def call(io, progname)
+        Thread.new do
+          io.each { |line| log(progname, line.chomp) }
+        end
+      end
+
+      def level?(level)
+        YleTf::Logger::LEVELS.include?(level)
+      end
+
+      def log(progname, line)
+        YleTf::Logger.public_send(level, progname) { line }
+      end
+    end
+  end
+end

--- a/lib/yle_tf/system/tf_hook_output_logger.rb
+++ b/lib/yle_tf/system/tf_hook_output_logger.rb
@@ -1,0 +1,33 @@
+require 'yle_tf/logger'
+require 'yle_tf/system/output_logger'
+
+class YleTf
+  class System
+    # An IO handler class for YleTf Hook output.
+    #
+    # Allows hooks to emit log messages with specific levels
+    # by prefixing a line with `<LEVEL>: `.
+    class TfHookOutputLogger < OutputLogger
+      def log(progname, line)
+        # Remove `[<progname>] ` prefix from the output line.
+        # This is mostly for backwards compatibility in Yle.
+        line.sub!(/^\[#{progname}\] /, '')
+
+        level, line = line_level(line)
+
+        YleTf::Logger.public_send(level, progname) { line }
+      end
+
+      # Extracts the log level from the line if found,
+      # otherwise returns the default level and the line as is
+      def line_level(line)
+        if (m = /^(?<level>[A-Z]+): (?<line>.*)$/.match(line))
+          line_level = m[:level].downcase.to_sym
+          return [line_level, m[:line]] if level?(line_level)
+        end
+
+        [level, line]
+      end
+    end
+  end
+end

--- a/lib/yle_tf/tf_hook.rb
+++ b/lib/yle_tf/tf_hook.rb
@@ -4,6 +4,7 @@ require 'tmpdir'
 require 'yle_tf/error'
 require 'yle_tf/logger'
 require 'yle_tf/system'
+require 'yle_tf/system/tf_hook_output_logger'
 
 class YleTf
   class TfHook
@@ -40,7 +41,13 @@ class YleTf
       fetch if !path
 
       Logger.info("Running hook '#{description}'")
-      YleTf::System.cmd(path, env: vars.merge(tf_vars), progname: File.basename(path))
+      YleTf::System.cmd(
+        path,
+        env: vars.merge(tf_vars),
+        progname: File.basename(path),
+        stdout: System::TfHookOutputLogger.new(:info),
+        stderr: System::TfHookOutputLogger.new(:error)
+      )
     ensure
       delete_tmpdir
     end

--- a/lib/yle_tf/tf_hook.rb
+++ b/lib/yle_tf/tf_hook.rb
@@ -39,8 +39,8 @@ class YleTf
     def run(tf_vars)
       fetch if !path
 
-      Logger.info("Running hook '#{description}'...")
-      YleTf::System.cmd(path, env: vars.merge(tf_vars))
+      Logger.info("Running hook '#{description}'")
+      YleTf::System.cmd(path, env: vars.merge(tf_vars), progname: File.basename(path))
     ensure
       delete_tmpdir
     end
@@ -64,9 +64,9 @@ class YleTf
     end
 
     def clone_git_repo(config)
-      Logger.info("Cloning hook '#{description}' from #{config[:uri]} (#{config[:ref]})")
+      Logger.debug("Cloning hook '#{description}' from #{config[:uri]} (#{config[:ref]})")
       YleTf::System.cmd(
-        'git', 'clone', '--no-progress', '--depth=1', '--branch', config[:ref],
+        'git', 'clone', '--quiet', '--depth=1', '--branch', config[:ref],
         '--', config[:uri], config[:dir]
       )
     end

--- a/lib/yle_tf_plugins/commands/__default/command.rb
+++ b/lib/yle_tf_plugins/commands/__default/command.rb
@@ -1,3 +1,4 @@
+require 'yle_tf/logger'
 require 'yle_tf/system'
 
 module YleTfPlugins
@@ -7,7 +8,8 @@ module YleTfPlugins
         command = env[:tf_command]
         args    = env[:tf_command_args]
 
-        YleTf::System.cmd('terraform', command, *args)
+        YleTf::Logger.info "Running `terraform #{command}`"
+        YleTf::System.console_cmd('terraform', command, *args)
       end
     end
   end

--- a/lib/yle_tf_plugins/commands/help/command.rb
+++ b/lib/yle_tf_plugins/commands/help/command.rb
@@ -1,5 +1,6 @@
 require 'optparse'
 
+require 'yle_tf/system'
 require 'yle_tf/plugin'
 
 module YleTfPlugins
@@ -46,9 +47,14 @@ module YleTfPlugins
       end
 
       def terraform_help
-        `terraform help`.lines.grep(/^    /)
-      rescue Errno::ENOENT
-        '    [Terraform not found]'
+        on_error = proc do |exit_code|
+          # exit_code is nil if the command was not found
+          # Ignore other exit codes, as older Terraform versions return
+          # non-zero exit codes for the help.
+          return '    [Terraform not found]' if exit_code.nil?
+        end
+        help = YleTf::System.read_cmd('terraform', '--help', error_handler: on_error)
+        help.lines.grep(/^    /)
       end
     end
   end

--- a/lib/yle_tf_plugins/commands/version/command.rb
+++ b/lib/yle_tf_plugins/commands/version/command.rb
@@ -1,5 +1,4 @@
-require 'optparse'
-
+require 'yle_tf/system'
 require 'yle_tf/version'
 
 module YleTfPlugins
@@ -11,9 +10,9 @@ module YleTfPlugins
       end
 
       def terraform_version
-        `terraform version`.lines.first
-      rescue Errno::ENOENT
-        '[Terraform not found]'
+        on_error = proc { return '[Terraform not found]' }
+        v = YleTf::System.read_cmd('terraform', 'version', error_handler: on_error)
+        v.lines.first
       end
     end
   end


### PR DESCRIPTION
Especially when initializing Terraform, redirect STDOUT as "debug" level to hide all the verbose output by default. The actual executed Terraform command will still use `system` as before.

Also allows YleTf hooks to emit log messages with specific levels by prefixing a line with `<LEVEL>: `, for example `DEBUG: foo`.