### PR TITLE
Deny interaction when initializing Terraform

### DIFF
--- a/lib/yle_tf/action/terraform_init.rb
+++ b/lib/yle_tf/action/terraform_init.rb
@@ -7,6 +7,8 @@ require 'yle_tf/version_requirement'
 class YleTf
   module Action
     class TerraformInit
+      TF_CMD_ARGS = %w[-input=false -no-color].freeze
+
       TF_CMD_OPTS = {
         env: { 'TF_IN_AUTOMATION' => 'true' }, # Reduces some output
         stdout: :debug                         # Hide the output to the debug level
@@ -35,18 +37,18 @@ class YleTf
       def init_pre_0_9(backend)
         cli_args = backend.cli_args
         if cli_args
-          YleTf::System.cmd('terraform', 'remote', 'config', '-no-color', *cli_args, TF_CMD_OPTS)
+          YleTf::System.cmd('terraform', 'remote', 'config', *TF_CMD_ARGS, *cli_args, TF_CMD_OPTS)
         end
 
         Logger.debug('Fetching Terraform modules')
-        YleTf::System.cmd('terraform', 'get', '-no-color', TF_CMD_OPTS)
+        YleTf::System.cmd('terraform', 'get', *TF_CMD_ARGS, TF_CMD_OPTS)
       end
 
       def init(backend)
         Logger.debug('Generating the backend configuration')
         backend.generate_config do
           Logger.debug('Initializing Terraform')
-          YleTf::System.cmd('terraform', 'init', '-no-color', TF_CMD_OPTS)
+          YleTf::System.cmd('terraform', 'init', *TF_CMD_ARGS, TF_CMD_OPTS)
         end
       end
 


### PR DESCRIPTION
The commands will output with DEBUG level which is hidden by default.
So the `tf` just seems to get stuck. Better to error out if interaction is needed.

Fixes #8