### PR TITLE
Handle IOErrors in IO Handlers

### DIFF
--- a/lib/yle_tf/system/io_handlers.rb
+++ b/lib/yle_tf/system/io_handlers.rb
@@ -1,3 +1,5 @@
+require 'yle_tf/error'
+require 'yle_tf/logger'
 require 'yle_tf/system/output_logger'
 
 class YleTf
@@ -69,7 +71,11 @@ class YleTf
       def self.dev_null_output
         lambda do |io, *|
           Thread.new do
-            while io.read; end
+            begin
+              while io.read; end
+            rescue IOError => e
+              YleTf::Logger.debug e.full_message
+            end
           end
         end
       end
@@ -100,6 +106,8 @@ class YleTf
         end
       rescue EOFError # rubocop:disable Lint/HandleExceptions
         # All read
+      rescue IOError => e
+        YleTf::Logger.debug e.full_message
       ensure
         target.close_write if opts[:close_target]
       end

--- a/lib/yle_tf/system/output_logger.rb
+++ b/lib/yle_tf/system/output_logger.rb
@@ -13,7 +13,11 @@ class YleTf
 
       def call(io, progname)
         Thread.new do
-          io.each { |line| log(progname, line.chomp) }
+          begin
+            io.each { |line| log(progname, line.chomp) }
+          rescue IOError => e
+            YleTf::Logger.debug e.full_message
+          end
         end
       end
 


### PR DESCRIPTION
Catch IOErrors when reading inputs on Threads to avoid output when the input IO is being closed due to e.g. Ctrl+C.

Still log the error with stack trace with debug level.