### PR TITLE
Ignore empty tfvar strings

### DIFF
--- a/lib/yle_tf/action/generate_vars_file.rb
+++ b/lib/yle_tf/action/generate_vars_file.rb
@@ -20,7 +20,7 @@ class YleTf
       end
 
       def tfvars(env)
-        env[:tfvars].merge(env[:config].fetch('tfvars'))
+        env[:tfvars].merge(env[:config].fetch('tfvars').select { |key, value| value.to_s.length() != 0 })
       end
     end
   end


### PR DESCRIPTION
Empty tfvars should probably just use default values defined in `variables.tf`, this PR proposes the removal of empty tfvars defined in `tf.yaml` at runtime.