### PR TITLE
Add support for Swift backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,8 @@ backend:
   type: s3
 ```
 
+Currently local file, S3, and Swift are supported.
+
 #### Terraform
 
 * `version_requirement` - The version requirement of Terraform in ruby gem syntax.

--- a/lib/yle_tf_plugins/backends/swift/command.rb
+++ b/lib/yle_tf_plugins/backends/swift/command.rb
@@ -1,0 +1,18 @@
+require 'yle_tf/backend_config'
+
+module YleTfPlugins
+  module Backends
+    module Swift
+      class Command
+        def backend_config(config)
+          YleTf::BackendConfig.new(
+            'swift',
+            'region_name' => config.fetch('backend', 'region'),
+            'container' => config.fetch('backend', 'container'),
+            'archive_container' => config.fetch('backend', 'archive_container') { nil }
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/yle_tf_plugins/backends/swift/plugin.rb
+++ b/lib/yle_tf_plugins/backends/swift/plugin.rb
@@ -1,0 +1,16 @@
+require 'yle_tf'
+
+module YleTfPlugins
+  module Backends
+    module Swift
+      class Plugin < YleTf::Plugin
+        register
+
+        backend('swift') do
+          require_relative 'command'
+          Command
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add support for using OpenStack Swift as a backend. [Terraform docs](https://www.terraform.io/docs/backends/types/swift.html).

Required configuration key: `container`. Optional: `region` and `archive_container`.