### PR TITLE
Drop support for Ruby v2.2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,9 @@
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
+
+Layout/AlignHash:
+  EnforcedHashRocketStyle: table
+  EnforcedColonStyle: table
 
 Metrics/AbcSize:
   Max: 16

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ before_install:
   - gem update --system
 
 rvm:
-  - 2.5.1
-  - 2.4.4
-  - 2.3.7
-  - 2.2.10
+  - 2.5.3
+  - 2.4.5
+  - 2.3.8

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in yle_tf.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 

--- a/bin/tf
+++ b/bin/tf
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Catch Ctrl+C to avoid stack traces
 Signal.trap('INT') { abort }

--- a/lib/yle_tf.rb
+++ b/lib/yle_tf.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yle_tf/logger'
 require 'yle_tf/version'
 

--- a/lib/yle_tf/action.rb
+++ b/lib/yle_tf/action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class YleTf
   module Action
     autoload :Builder, 'yle_tf/action/builder'

--- a/lib/yle_tf/action/builder.rb
+++ b/lib/yle_tf/action/builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../vendor/middleware/builder'
 
 class YleTf

--- a/lib/yle_tf/action/command.rb
+++ b/lib/yle_tf/action/command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yle_tf/logger'
 
 class YleTf

--- a/lib/yle_tf/action/copy_root_module.rb
+++ b/lib/yle_tf/action/copy_root_module.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fileutils'
 
 require 'yle_tf/logger'

--- a/lib/yle_tf/action/generate_vars_file.rb
+++ b/lib/yle_tf/action/generate_vars_file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yle_tf/logger'
 require 'yle_tf/vars_file'
 

--- a/lib/yle_tf/action/load_config.rb
+++ b/lib/yle_tf/action/load_config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yle_tf/config'
 
 class YleTf

--- a/lib/yle_tf/action/terraform_init.rb
+++ b/lib/yle_tf/action/terraform_init.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yle_tf/error'
 require 'yle_tf/logger'
 require 'yle_tf/plugin'
@@ -10,8 +12,8 @@ class YleTf
       TF_CMD_ARGS = %w[-input=false -no-color].freeze
 
       TF_CMD_OPTS = {
-        env: { 'TF_IN_AUTOMATION' => 'true' }, # Reduces some output
-        stdout: :debug                         # Hide the output to the debug level
+        env:    { 'TF_IN_AUTOMATION' => 'true' }, # Reduces some output
+        stdout: :debug                            # Hide the output to the debug level
       }.freeze
 
       def initialize(app)

--- a/lib/yle_tf/action/tf_hooks.rb
+++ b/lib/yle_tf/action/tf_hooks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yle_tf/logger'
 require 'yle_tf/tf_hook/runner'
 

--- a/lib/yle_tf/action/tmpdir.rb
+++ b/lib/yle_tf/action/tmpdir.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fileutils'
 require 'tmpdir'
 

--- a/lib/yle_tf/action/verify_terraform_version.rb
+++ b/lib/yle_tf/action/verify_terraform_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yle_tf/error'
 require 'yle_tf/logger'
 require 'yle_tf/system'

--- a/lib/yle_tf/action/verify_tf_env.rb
+++ b/lib/yle_tf/action/verify_tf_env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yle_tf/error'
 require 'yle_tf/vars_file'
 

--- a/lib/yle_tf/action/write_terraformrc_defaults.rb
+++ b/lib/yle_tf/action/write_terraformrc_defaults.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fileutils'
 require 'yle_tf/logger'
 
@@ -5,10 +7,10 @@ class YleTf
   module Action
     class WriteTerraformrcDefaults
       # Path of the Terraform CLI configuration file
-      RC_PATH = '~/.terraformrc'.freeze
+      RC_PATH = '~/.terraformrc'
 
       # Path of the plugin cache directory
-      DEFAULT_PLUGIN_CACHE_PATH = '~/.terraform.d/plugin-cache'.freeze
+      DEFAULT_PLUGIN_CACHE_PATH = '~/.terraform.d/plugin-cache'
 
       def initialize(app)
         @app = app

--- a/lib/yle_tf/backend_config.rb
+++ b/lib/yle_tf/backend_config.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 require 'json'
 
 class YleTf
   class BackendConfig
-    BACKEND_CONFIG_FILE = '_backend.tf.json'.freeze
+    BACKEND_CONFIG_FILE = '_backend.tf.json'
 
     attr_reader :type, :config
 

--- a/lib/yle_tf/cli.rb
+++ b/lib/yle_tf/cli.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yle_tf'
 
 class YleTf

--- a/lib/yle_tf/config.rb
+++ b/lib/yle_tf/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 require 'yaml'
 
@@ -34,6 +36,7 @@ class YleTf
 
       keys.inject(config) do |conf, key|
         break block.call(keys) if !conf || !conf.key?(key)
+
         conf[key]
       end
     end

--- a/lib/yle_tf/config/defaults.rb
+++ b/lib/yle_tf/config/defaults.rb
@@ -1,19 +1,21 @@
+# frozen_string_literal: true
+
 class YleTf
   class Config
     module Defaults
       DEFAULT_CONFIG = {
-        'hooks' => {
-          'pre' => [],
+        'hooks'     => {
+          'pre'  => [],
           'post' => []
         },
-        'backend' => {
-          'type' => 'file',
+        'backend'   => {
+          'type'    => 'file',
           'bucket'  => nil,
           'file'    => '<%= @module %>_<%= @env %>.tfstate',
           'region'  => nil,
           'encrypt' => false,
         },
-        'tfvars' => {
+        'tfvars'    => {
         },
         'terraform' => {
           'version_requirement' => nil
@@ -26,7 +28,7 @@ class YleTf
 
       def default_config_context
         {
-          env: tf_env,
+          env:    tf_env,
           module: module_dir.basename.to_s,
         }
       end

--- a/lib/yle_tf/config/erb.rb
+++ b/lib/yle_tf/config/erb.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'erb'
 
 class YleTf

--- a/lib/yle_tf/config/file.rb
+++ b/lib/yle_tf/config/file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yaml'
 
 require 'yle_tf/logger'

--- a/lib/yle_tf/config/loader.rb
+++ b/lib/yle_tf/config/loader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yle_tf/config/defaults'
 require 'yle_tf/config/erb'
 require 'yle_tf/config/file'
@@ -58,8 +60,7 @@ class YleTf
         Plugin.manager.default_configs.each do |plugin_config|
           deep_merge(
             config, plugin_config,
-            error_msg:
-              "Failed to merge a plugin's default configuration:\n" \
+            error_msg: "Failed to merge a plugin's default configuration:\n" \
               "#{plugin_config.inspect}\ninto:\n#{config.inspect}"
           )
         end
@@ -70,8 +71,7 @@ class YleTf
           Logger.debug("  - #{file}")
           deep_merge(
             config, file.read,
-            error_msg:
-              "Failed to merge configuration from '#{file}' into:\n" \
+            error_msg: "Failed to merge configuration from '#{file}' into:\n" \
               "#{config.inspect}"
           )
         end

--- a/lib/yle_tf/error.rb
+++ b/lib/yle_tf/error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class YleTf
   # Base class for yle_tf errors
   Error = Class.new(StandardError)

--- a/lib/yle_tf/logger.rb
+++ b/lib/yle_tf/logger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'forwardable'
 require 'logger'
 require 'rubygems'

--- a/lib/yle_tf/logger/colorize.rb
+++ b/lib/yle_tf/logger/colorize.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class YleTf
   module Logger
     module Colorize

--- a/lib/yle_tf/plugin.rb
+++ b/lib/yle_tf/plugin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class YleTf
   class Plugin
     autoload :ActionHook, 'yle_tf/plugin/action_hook'
@@ -30,7 +32,7 @@ class YleTf
       name = name.to_s if name.is_a?(Symbol)
       commands[name] = {
         synopsis: synopsis,
-        proc: block
+        proc:     block
       }
     end
 

--- a/lib/yle_tf/plugin/action_hook.rb
+++ b/lib/yle_tf/plugin/action_hook.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class YleTf
   class Plugin
     class ActionHook

--- a/lib/yle_tf/plugin/loader.rb
+++ b/lib/yle_tf/plugin/loader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yle_tf/logger'
 
 class YleTf

--- a/lib/yle_tf/plugin/manager.rb
+++ b/lib/yle_tf/plugin/manager.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yle_tf/logger'
 
 class YleTf

--- a/lib/yle_tf/system.rb
+++ b/lib/yle_tf/system.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'English'
 require 'open3'
 require 'shellwords'
@@ -14,7 +16,7 @@ class YleTf
     DEFAULT_ERROR_HANDLER = ->(_exit_code, error) { raise error }.freeze
 
     DEFAULT_IO_HANDLERS = {
-      stdin: :dev_null,
+      stdin:  :dev_null,
       stdout: :info,
       stderr: :error
     }.freeze

--- a/lib/yle_tf/system/io_handlers.rb
+++ b/lib/yle_tf/system/io_handlers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yle_tf/error'
 require 'yle_tf/logger'
 require 'yle_tf/system/output_logger'
@@ -22,6 +24,7 @@ class YleTf
           if !handler.respond_to?(:call)
             raise YleTf::Error, "Unknown input handler #{handler.inspect}"
           end
+
           handler
         end
       end
@@ -42,6 +45,7 @@ class YleTf
           if !handler.respond_to?(:call)
             raise YleTf::Error, "Unknown output handler #{handler.inspect}"
           end
+
           handler
         end
       end

--- a/lib/yle_tf/system/output_logger.rb
+++ b/lib/yle_tf/system/output_logger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yle_tf/logger'
 
 class YleTf

--- a/lib/yle_tf/system/tf_hook_output_logger.rb
+++ b/lib/yle_tf/system/tf_hook_output_logger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yle_tf/logger'
 require 'yle_tf/system/output_logger'
 

--- a/lib/yle_tf/tf_hook.rb
+++ b/lib/yle_tf/tf_hook.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fileutils'
 require 'tmpdir'
 
@@ -14,8 +16,8 @@ class YleTf
     def self.from_config(config, tf_env)
       TfHook.new(
         description: config['description'],
-        source: config['source'],
-        vars: merge_vars(config['vars'], tf_env)
+        source:      config['source'],
+        vars:        merge_vars(config['vars'], tf_env)
       )
     end
 
@@ -23,7 +25,7 @@ class YleTf
     def self.from_file(path)
       TfHook.new(
         description: File.basename(path),
-        path: path
+        path:        path
       )
     end
 
@@ -43,10 +45,10 @@ class YleTf
       Logger.info("Running hook '#{description}'")
       YleTf::System.cmd(
         path,
-        env: vars.merge(tf_vars),
+        env:      vars.merge(tf_vars),
         progname: File.basename(path),
-        stdout: System::TfHookOutputLogger.new(:info),
-        stderr: System::TfHookOutputLogger.new(:error)
+        stdout:   System::TfHookOutputLogger.new(:info),
+        stderr:   System::TfHookOutputLogger.new(:error)
       )
     ensure
       delete_tmpdir
@@ -57,9 +59,9 @@ class YleTf
       raise Error, "Invalid or missing `source` for hook '#{description}'" if !m
 
       {
-        uri: m[:uri],
+        uri:  m[:uri],
         path: m[:path],
-        ref: m[:ref] || 'master'
+        ref:  m[:ref] || 'master'
       }
     end
 

--- a/lib/yle_tf/tf_hook/runner.rb
+++ b/lib/yle_tf/tf_hook/runner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yle_tf/logger'
 require 'yle_tf/tf_hook'
 

--- a/lib/yle_tf/vars_file.rb
+++ b/lib/yle_tf/vars_file.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 class YleTf
   class VarsFile
-    ENV_DIR = 'envs'.freeze
+    ENV_DIR = 'envs'
 
     # Returns the env specific tfvars file path if it exists
     def self.find_env_vars_file(config)

--- a/lib/yle_tf/version.rb
+++ b/lib/yle_tf/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class YleTf
-  VERSION = '1.0.1.dev'.freeze
+  VERSION = '1.0.1.dev'
 end

--- a/lib/yle_tf/version_requirement.rb
+++ b/lib/yle_tf/version_requirement.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubygems'
 
 class YleTf

--- a/lib/yle_tf_plugins/backends/file/command.rb
+++ b/lib/yle_tf_plugins/backends/file/command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'config'
 
 module YleTfPlugins

--- a/lib/yle_tf_plugins/backends/file/config.rb
+++ b/lib/yle_tf_plugins/backends/file/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yle_tf/backend_config'
 
 module YleTfPlugins

--- a/lib/yle_tf_plugins/backends/file/plugin.rb
+++ b/lib/yle_tf_plugins/backends/file/plugin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yle_tf'
 
 module YleTfPlugins

--- a/lib/yle_tf_plugins/backends/s3/command.rb
+++ b/lib/yle_tf_plugins/backends/s3/command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yle_tf/backend_config'
 
 module YleTfPlugins
@@ -7,9 +9,9 @@ module YleTfPlugins
         def backend_config(config)
           YleTf::BackendConfig.new(
             's3',
-            'region' => config.fetch('backend', 'region'),
-            'bucket' => config.fetch('backend', 'bucket'),
-            'key' => config.fetch('backend', 'file'),
+            'region'  => config.fetch('backend', 'region'),
+            'bucket'  => config.fetch('backend', 'bucket'),
+            'key'     => config.fetch('backend', 'file'),
             'encrypt' => config.fetch('backend', 'encrypt')
           )
         end

--- a/lib/yle_tf_plugins/backends/s3/plugin.rb
+++ b/lib/yle_tf_plugins/backends/s3/plugin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yle_tf'
 
 module YleTfPlugins

--- a/lib/yle_tf_plugins/backends/swift/command.rb
+++ b/lib/yle_tf_plugins/backends/swift/command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yle_tf/backend_config'
 
 module YleTfPlugins
@@ -7,8 +9,8 @@ module YleTfPlugins
         def backend_config(config)
           YleTf::BackendConfig.new(
             'swift',
-            'region_name' => config.fetch('backend', 'region'),
-            'container' => config.fetch('backend', 'container'),
+            'region_name'       => config.fetch('backend', 'region'),
+            'container'         => config.fetch('backend', 'container'),
             'archive_container' => config.fetch('backend', 'archive_container') { nil }
           )
         end

--- a/lib/yle_tf_plugins/backends/swift/plugin.rb
+++ b/lib/yle_tf_plugins/backends/swift/plugin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yle_tf'
 
 module YleTfPlugins

--- a/lib/yle_tf_plugins/commands/__default/command.rb
+++ b/lib/yle_tf_plugins/commands/__default/command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yle_tf/logger'
 require 'yle_tf/system'
 

--- a/lib/yle_tf_plugins/commands/__default/plugin.rb
+++ b/lib/yle_tf_plugins/commands/__default/plugin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yle_tf'
 
 module YleTfPlugins

--- a/lib/yle_tf_plugins/commands/_config/command.rb
+++ b/lib/yle_tf_plugins/commands/_config/command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yle_tf/logger'
 
 module YleTfPlugins

--- a/lib/yle_tf_plugins/commands/_config/plugin.rb
+++ b/lib/yle_tf_plugins/commands/_config/plugin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yle_tf'
 
 module YleTfPlugins

--- a/lib/yle_tf_plugins/commands/_shell/command.rb
+++ b/lib/yle_tf_plugins/commands/_shell/command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module YleTfPlugins
   module CommandShell
     class Command

--- a/lib/yle_tf_plugins/commands/_shell/plugin.rb
+++ b/lib/yle_tf_plugins/commands/_shell/plugin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yle_tf'
 
 module YleTfPlugins

--- a/lib/yle_tf_plugins/commands/help/command.rb
+++ b/lib/yle_tf_plugins/commands/help/command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'optparse'
 
 require 'yle_tf/system'

--- a/lib/yle_tf_plugins/commands/help/plugin.rb
+++ b/lib/yle_tf_plugins/commands/help/plugin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yle_tf'
 
 module YleTfPlugins

--- a/lib/yle_tf_plugins/commands/version/command.rb
+++ b/lib/yle_tf_plugins/commands/version/command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yle_tf/system'
 require 'yle_tf/version'
 

--- a/lib/yle_tf_plugins/commands/version/plugin.rb
+++ b/lib/yle_tf_plugins/commands/version/plugin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yle_tf'
 
 module YleTfPlugins

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'yle_tf'

--- a/spec/yle_tf/tf_hook_spec.rb
+++ b/spec/yle_tf/tf_hook_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 require 'open3'
@@ -12,8 +14,8 @@ describe YleTf::TfHook do
     let(:conf) do
       {
         'description' => description,
-        'source' => source,
-        'vars' => vars
+        'source'      => source,
+        'vars'        => vars
       }
     end
     let(:description) { 'Hook description' }
@@ -53,8 +55,8 @@ describe YleTf::TfHook do
         let(:vars) do
           {
             'defaults' => { 'FOO' => 'bar', 'MEMORY' => '5TB' },
-            env => { 'DIU' => 'dau', 'MEMORY' => '2TB' },
-            'dummy' => { 'FOO' => 'baz' }
+            env        => { 'DIU' => 'dau', 'MEMORY' => '2TB' },
+            'dummy'    => { 'FOO' => 'baz' }
           }
         end
         it 'returns the vars merged' do
@@ -91,7 +93,7 @@ describe YleTf::TfHook do
           let(:vars) do
             {
               'defaults' => { 'FOO' => 'bar', 'MEMORY' => '5TB' },
-              env => { 'DIU' => 'dau', 'MEMORY' => '2TB' }
+              env        => { 'DIU' => 'dau', 'MEMORY' => '2TB' }
             }
           end
           let(:expected_vars) do

--- a/spec/yle_tf/vars_file_spec.rb
+++ b/spec/yle_tf/vars_file_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 require 'ostruct'

--- a/spec/yle_tf_spec.rb
+++ b/spec/yle_tf_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe YleTf do

--- a/yle_tf.gemspec
+++ b/yle_tf.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'yle_tf/version'
@@ -29,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.executables   = ['tf']
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.2'
+  spec.required_ruby_version = '>= 2.3'
 
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'rake', '~> 12.0'


### PR DESCRIPTION
Ruby 2.2 reached EOL on 2018-06-20:
  https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/

- Require Ruby 2.3+ for the gem
- Upgrade Ruby version matrix in Travis build
- Upgrade Rubocop Rules for 2.3+ and fix also new rules.