### PR TITLE
Add `module_dir` to the tf.yml evaluation context

### DIFF
--- a/lib/yle_tf/config/defaults.rb
+++ b/lib/yle_tf/config/defaults.rb
@@ -28,8 +28,9 @@ class YleTf
 
       def default_config_context
         {
-          env:    tf_env,
-          module: module_dir.basename.to_s,
+          env:        tf_env,
+          module:     module_dir.basename.to_s,
+          module_dir: module_dir.to_s,
         }
       end
     end


### PR DESCRIPTION
Make it easier to build e.g. unique backend S3 object names based on the full path to the module.