### PR TITLE
Fix `Config.fetch` when a key is not a Hash and refactor config loading

### DIFF
--- a/lib/yle_tf/action/load_config.rb
+++ b/lib/yle_tf/action/load_config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'yle_tf/config'
+require 'yle_tf/logger'
 
 class YleTf
   module Action
@@ -10,9 +11,14 @@ class YleTf
       end
 
       def call(env)
-        env[:config] ||= Config.new(env[:tf_env])
+        env[:config] ||= load_config(env[:tf_env])
 
         @app.call(env)
+      end
+
+      def load_config(tf_env)
+        Logger.debug("Initializing configuration for the #{tf_env.inspect} environment")
+        Config.load(tf_env).tap { |config| Logger.debug(config.inspect) }
       end
     end
   end

--- a/lib/yle_tf/config.rb
+++ b/lib/yle_tf/config.rb
@@ -35,7 +35,7 @@ class YleTf
       block ||= DEFAULT_NOT_FOUND_BLOCK
 
       keys.inject(config) do |conf, key|
-        break block.call(keys) if !conf || !conf.key?(key)
+        break block.call(keys) if conf.nil? || !conf.is_a?(Hash) || !conf.key?(key)
 
         conf[key]
       end

--- a/lib/yle_tf/config.rb
+++ b/lib/yle_tf/config.rb
@@ -5,23 +5,29 @@ require 'yaml'
 
 require 'yle_tf/config/loader'
 require 'yle_tf/error'
-require 'yle_tf/logger'
 
 class YleTf
   # Configuration object to be used especially by the middleware stack
   class Config
     NotFoundError = Class.new(Error)
 
+    # Loads the configuration based on the environment
+    def self.load(tf_env)
+      opts = {
+        tf_env:     tf_env,
+        module_dir: Pathname.pwd
+      }
+
+      config = Loader.new(opts).load
+      new(config, opts)
+    end
+
     attr_reader :config, :tf_env, :module_dir
 
-    def initialize(tf_env)
-      Logger.debug("Initializing configuration for the #{tf_env.inspect} environment")
-
-      @tf_env = tf_env
-      @module_dir = Pathname.pwd
-      @config = Loader.new(tf_env: tf_env, module_dir: module_dir).load
-
-      Logger.debug(inspect)
+    def initialize(config, **opts)
+      @config = config
+      @tf_env = opts[:tf_env]
+      @module_dir = opts[:module_dir]
     end
 
     def to_s

--- a/test/unit/yle_tf/action/load_config_spec.rb
+++ b/test/unit/yle_tf/action/load_config_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'yle_tf/action/load_config'
+require 'yle_tf/config'
+
+describe YleTf::Action::LoadConfig do
+  describe '#call' do
+    before { allow(YleTf::Config).to receive(:load) }
+
+    subject(:action) { described_class.new(app).call(env) }
+
+    let(:app) { double('app', call: nil) }
+    let(:env) { { tf_env: tf_env, config: config } }
+    let(:tf_env) { 'myenv' }
+
+    let(:dummy_config) { YleTf::Config.new('foo' => 'bar') }
+
+    context 'when config not yet loaded' do
+      let(:config) { nil }
+
+      it 'loads the config' do
+        expect(YleTf::Config).to receive(:load).with(tf_env) { dummy_config }
+        action
+      end
+
+      it 'calls next app' do
+        expect(app).to receive(:call).with(env)
+        action
+      end
+    end
+
+    context 'when already loaded' do
+      let(:config) { dummy_config }
+
+      it 'does not load the config again' do
+        expect(YleTf::Config).not_to receive(:load)
+        action
+      end
+
+      it 'calls next app' do
+        expect(app).to receive(:call).with(env)
+        action
+      end
+    end
+  end
+end

--- a/test/unit/yle_tf/config_spec.rb
+++ b/test/unit/yle_tf/config_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'yle_tf/config'
+
+describe YleTf::Config do
+  subject(:config) { described_class.new(config_hash, opts) }
+  let(:config_hash) { {} }
+  let(:opts) { {} }
+
+  describe '#config' do
+    subject { config.config }
+    let(:config_hash) { { 'foo' => 'bar' } }
+
+    it { is_expected.to eq('foo' => 'bar') }
+  end
+
+  describe '#tf_env' do
+    subject { config.tf_env }
+    let(:opts) { { tf_env: 'myenv' } }
+
+    it { is_expected.to eq('myenv') }
+  end
+
+  describe '#module_dir' do
+    subject { config.module_dir }
+    let(:opts) { { module_dir: '/foo/bar' } }
+
+    it { is_expected.to eq('/foo/bar') }
+  end
+
+  describe '#fetch' do
+    let(:config_hash) do
+      {
+        'foo'  => 'bar',
+        'some' => {
+          'deep'      => {
+            'thing' => 99
+          },
+          'nil_value' => nil
+        }
+      }
+    end
+
+    it 'returns first level keys' do
+      expect(config.fetch('foo')).to eq('bar')
+    end
+
+    it 'returns hierarchial keys' do
+      expect(config.fetch('some', 'deep', 'thing')).to eq(99)
+    end
+
+    it 'returns nil values' do
+      expect(config.fetch('some', 'nil_value')).to be_nil
+    end
+
+    it 'returns hashes' do
+      expect(config.fetch('some', 'deep')).to eq('thing' => 99)
+    end
+
+    context 'with default block' do
+      it { expect { config.fetch('non_existing') }.to raise_error(YleTf::Config::NotFoundError) }
+    end
+
+    context 'with specified block' do
+      let(:subject) { config.fetch('foo', 'bar', &block) }
+      let(:block) { ->(_keys) { 'my_default_value' } }
+
+      it { is_expected.to eq('my_default_value') }
+
+      it 'calls the block' do
+        expect(block).to receive(:call).with(%w[foo bar])
+        subject
+      end
+    end
+  end
+end


### PR DESCRIPTION
With config like:

```yaml
foo:
  bar: something
```

`fetch('foo', 'bar', 'baz')` raised an exception instead of normal "key not found" handling.

Also make the `Config` class easier to test by extracting loading out of the constructor, and add some unit tests.