### PR TITLE
 Drop (broken) support for Terraform 0.8 and older

### DIFF
--- a/lib/yle_tf.rb
+++ b/lib/yle_tf.rb
@@ -4,6 +4,8 @@ require 'yle_tf/logger'
 require 'yle_tf/version'
 
 class YleTf
+  TERRAFORM_VERSION_REQUIREMENT = '>= 0.9'
+
   autoload :Action,  'yle_tf/action'
   autoload :Error,   'yle_tf/error'
   autoload :Plugin,  'yle_tf/plugin'

--- a/lib/yle_tf/action/terraform_init.rb
+++ b/lib/yle_tf/action/terraform_init.rb
@@ -4,7 +4,6 @@ require 'yle_tf/error'
 require 'yle_tf/logger'
 require 'yle_tf/plugin'
 require 'yle_tf/system'
-require 'yle_tf/version_requirement'
 
 class YleTf
   module Action
@@ -27,31 +26,16 @@ class YleTf
         Logger.info('Initializing Terraform')
         Logger.debug("Backend configuration: #{backend}")
 
-        if VersionRequirement.pre_0_9?(env[:terraform_version])
-          init_pre_0_9(backend)
-        else
-          init(backend)
-        end
+        init(backend)
 
         @app.call(env)
       end
 
-      def init_pre_0_9(backend)
-        cli_args = backend.cli_args
-        if cli_args
-          YleTf::System.cmd('terraform', 'remote', 'config', *TF_CMD_ARGS, *cli_args, TF_CMD_OPTS)
-        end
-
-        Logger.debug('Fetching Terraform modules')
-        YleTf::System.cmd('terraform', 'get', *TF_CMD_ARGS, TF_CMD_OPTS)
-      end
-
       def init(backend)
-        Logger.debug('Generating the backend configuration')
-        backend.generate_config do
-          Logger.debug('Initializing Terraform')
-          YleTf::System.cmd('terraform', 'init', *TF_CMD_ARGS, TF_CMD_OPTS)
-        end
+        Logger.debug('Configuring the backend')
+        backend.generate_config
+        Logger.debug('Initializing Terraform')
+        YleTf::System.cmd('terraform', 'init', *TF_CMD_ARGS, TF_CMD_OPTS)
       end
 
       def backend_config(config)

--- a/lib/yle_tf/backend_config.rb
+++ b/lib/yle_tf/backend_config.rb
@@ -13,15 +13,6 @@ class YleTf
       @config = config
     end
 
-    # Returns an `Array` of CLI args for Terraform pre 0.9 `init` command
-    def cli_args
-      args = ["-backend=#{type}"]
-      config.each do |key, value|
-        args << "-backend-config=#{key}=#{value}"
-      end
-      args
-    end
-
     # Generate backend configuration file for Terraform v0.9+
     def generate_config
       data = {
@@ -30,7 +21,6 @@ class YleTf
         }]
       }
       File.write(BACKEND_CONFIG_FILE, JSON.pretty_generate(data))
-      yield if block_given?
     end
 
     # Returns the backend configuration as a `Hash` for Terraform v0.9+

--- a/lib/yle_tf/version_requirement.rb
+++ b/lib/yle_tf/version_requirement.rb
@@ -5,11 +5,6 @@ require 'rubygems'
 class YleTf
   # Helper class for comparing versions
   class VersionRequirement
-    # Checks if the specified Terrform version is older than 0.9
-    def self.pre_0_9?(terraform_version)
-      new('< 0.9.0-beta').satisfied_by?(terraform_version)
-    end
-
     attr_reader :requirement
 
     def initialize(requirement)

--- a/lib/yle_tf_plugins/backends/file/config.rb
+++ b/lib/yle_tf_plugins/backends/file/config.rb
@@ -7,11 +7,7 @@ module YleTfPlugins
     module File
       class Config < YleTf::BackendConfig
         def generate_config
-          yield if block_given?
-        end
-
-        def cli_args
-          nil
+          # Do nothing, as the state file is just symlinked
         end
       end
     end

--- a/test/unit/yle_tf/action/verify_terraform_version_spec.rb
+++ b/test/unit/yle_tf/action/verify_terraform_version_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'yle_tf/action/verify_terraform_version'
+require 'yle_tf/config'
+require 'yle_tf/error'
+
+describe YleTf::Action::VerifyTerraformVersion do
+  subject(:action) { described_class.new(app) }
+
+  let(:app) { double('app', call: nil) }
+
+  describe '#call' do
+    before do
+      stub_const('YleTf::TERRAFORM_VERSION_REQUIREMENT', '>= 1.1')
+      allow(action).to receive(:terraform_version) { terraform_version }
+    end
+
+    subject(:call) { action.call(env) }
+
+    let(:env) { { config: config } }
+    let(:config) do
+      YleTf::Config.new('terraform' => {
+                          'version_requirement' => config_requirement
+                        })
+    end
+    let(:config_requirement) { nil }
+
+    context 'when Terraform not found' do
+      let(:terraform_version) { nil }
+
+      it { expect { call }.to raise_error(YleTf::Error, 'Terraform not found') }
+    end
+
+    context 'without configuration' do
+      let(:config_requirement) { nil }
+
+      context 'with supported Terraform version' do
+        let(:terraform_version) { '1.2.3' }
+
+        it 'stores the version to env' do
+          call
+          expect(env[:terraform_version]).to eq('1.2.3')
+        end
+
+        it 'calls next app' do
+          expect(app).to receive(:call).with(env)
+          call
+        end
+      end
+
+      context 'with unsupported Terraform version' do
+        let(:terraform_version) { '0.11.11' }
+
+        it do
+          expect { call }.to raise_error(
+            YleTf::Error, "Terraform version '>= 1.1' required by YleTf, '0.11.11' found"
+          )
+        end
+      end
+    end
+
+    context 'with configuration' do
+      let(:config_requirement) { '~> 1.3.7' }
+
+      context 'with supported Terraform version' do
+        context 'when accepted by config' do
+          let(:terraform_version) { '1.3.12' }
+
+          it 'stores the version to env' do
+            call
+            expect(env[:terraform_version]).to eq('1.3.12')
+          end
+
+          it 'calls next app' do
+            expect(app).to receive(:call).with(env)
+            call
+          end
+        end
+
+        context 'when denied by config' do
+          let(:terraform_version) { '1.5.0' }
+          it do
+            expect { call }.to raise_error(
+              YleTf::Error, "Terraform version '~> 1.3.7' required by config, '1.5.0' found"
+            )
+          end
+        end
+      end
+
+      context 'with unsupported Terraform version' do
+        let(:terraform_version) { '0.11.11' }
+
+        it do
+          expect { call }.to raise_error(
+            YleTf::Error, "Terraform version '>= 1.1' required by YleTf, '0.11.11' found"
+          )
+        end
+      end
+    end
+  end
+end

--- a/test/unit/yle_tf/version_requirement_spec.rb
+++ b/test/unit/yle_tf/version_requirement_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require 'yle_tf/version_requirement'
+
+describe YleTf::VersionRequirement do
+  subject(:requirement) { described_class.new(requirements) }
+
+  describe '#satisfied_by?' do
+    context 'with no requirements' do
+      let(:requirements) { nil }
+
+      it 'satisfies all versions' do
+        expect(requirement).to be_satisfied_by('0.11.11')
+        expect(requirement).to be_satisfied_by('1.2.3-rc4')
+      end
+    end
+
+    context 'with empty requirements' do
+      let(:requirements) { [] }
+
+      it 'satisfies all versions' do
+        expect(requirement).to be_satisfied_by('0.11.11')
+        expect(requirement).to be_satisfied_by('1.2.3-rc4')
+      end
+    end
+
+    context 'with minimun requirement' do
+      let(:requirements) { '>= 0.10' }
+
+      it 'does not satisfy older versions' do
+        expect(requirement).not_to be_satisfied_by('0.8.8')
+        expect(requirement).not_to be_satisfied_by('0.10.0-beta2')
+      end
+
+      it 'satisfies the exact version' do
+        expect(requirement).to be_satisfied_by('0.10')
+        expect(requirement).to be_satisfied_by('0.10.0')
+      end
+
+      it 'satisfies newer versions' do
+        expect(requirement).to be_satisfied_by('0.11.11')
+        expect(requirement).to be_satisfied_by('1.2.3-rc4')
+      end
+    end
+
+    context 'with minimun requirement' do
+      let(:requirements) { '>= 0.10' }
+
+      it 'does not satisfy older versions' do
+        expect(requirement).not_to be_satisfied_by('0.8.8')
+        expect(requirement).not_to be_satisfied_by('0.10.0-beta2')
+      end
+
+      it 'satisfies the exact version' do
+        expect(requirement).to be_satisfied_by('0.10')
+        expect(requirement).to be_satisfied_by('0.10.0')
+      end
+
+      it 'satisfies newer versions' do
+        expect(requirement).to be_satisfied_by('0.11.11')
+        expect(requirement).to be_satisfied_by('1.2.3-rc4')
+      end
+    end
+
+    context 'with multiple requirements' do
+      let(:requirements) { ['>= 0.9.10', '< 0.11'] }
+
+      it 'does not satisfy older versions' do
+        expect(requirement).not_to be_satisfied_by('0.8.8')
+        expect(requirement).not_to be_satisfied_by('0.9.5')
+      end
+
+      it 'satisfies the correct version' do
+        expect(requirement).to be_satisfied_by('0.9.10')
+        expect(requirement).to be_satisfied_by('0.10.8')
+      end
+
+      it 'does not satisfy newer versions' do
+        expect(requirement).not_to be_satisfied_by('0.11.11')
+        expect(requirement).not_to be_satisfied_by('1.2.3-rc4')
+      end
+    end
+
+    context 'with pessimistic version constraint' do
+      let(:requirements) { ['~> 0.10.3'] }
+
+      it 'does not satisfy older versions' do
+        expect(requirement).not_to be_satisfied_by('0.8.8')
+        expect(requirement).not_to be_satisfied_by('0.10.1')
+      end
+
+      it 'satisfies the correct version' do
+        expect(requirement).to be_satisfied_by('0.10.3')
+        expect(requirement).to be_satisfied_by('0.10.8')
+      end
+
+      it 'does not satisfy newer versions' do
+        expect(requirement).not_to be_satisfied_by('0.11.11')
+        expect(requirement).not_to be_satisfied_by('1.2.3-rc4')
+      end
+    end
+  end
+end


### PR DESCRIPTION
The support has been actually broken for year now, since PR #9. Nobody has complained, so clean up the code base a bit.

Anyway, add a check and clear error message for old Terraform versions. And unit tests. Yay!
