### PR TITLE
Allow configuring YleTf version requirement in tf.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,15 @@ terraform:
   version_requirement: "~> 0.9.11"
 ```
 
+#### YleTf
+
+* `version_requirement` - The version requirement of YleTf in ruby gem syntax.
+
+```yaml
+yle_tf:
+  version_requirement: ">= 1.2"
+```
+
 ## Plugins
 
 Available plugins are listed on the [wiki page](https://github.com/Yleisradio/yle_tf/wiki#plugins)

--- a/lib/yle_tf/action.rb
+++ b/lib/yle_tf/action.rb
@@ -12,11 +12,13 @@ class YleTf
     autoload :TmpDir, 'yle_tf/action/tmpdir'
     autoload :VerifyTerraformVersion, 'yle_tf/action/verify_terraform_version'
     autoload :VerifyTfEnv, 'yle_tf/action/verify_tf_env'
+    autoload :VerifyYleTfVersion, 'yle_tf/action/verify_yle_tf_version'
     autoload :WriteTerraformrcDefaults, 'yle_tf/action/write_terraformrc_defaults'
 
     def self.default_action_stack(command_class = nil)
       Builder.new do
         use LoadConfig
+        use VerifyYleTfVersion
         use VerifyTfEnv
         use TmpDir
         use WriteTerraformrcDefaults

--- a/lib/yle_tf/action/verify_yle_tf_version.rb
+++ b/lib/yle_tf/action/verify_yle_tf_version.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'yle_tf/error'
+require 'yle_tf/logger'
+require 'yle_tf/version'
+require 'yle_tf/version_requirement'
+
+class YleTf
+  module Action
+    class VerifyYleTfVersion
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        Logger.debug('Verifying YleTf version')
+
+        requirement = requirement(env[:config])
+        verify_version(requirement)
+
+        @app.call(env)
+      end
+
+      def requirement(config)
+        requirement = config.fetch('yle_tf', 'version_requirement') { nil }
+        VersionRequirement.new(requirement)
+      end
+
+      def verify_version(requirement)
+        return if requirement.satisfied_by?(YleTf::VERSION)
+
+        raise Error, "YleTf version '#{YleTf::VERSION}', '#{requirement}' required by config"
+      end
+    end
+  end
+end

--- a/lib/yle_tf/config/defaults.rb
+++ b/lib/yle_tf/config/defaults.rb
@@ -23,6 +23,9 @@ class YleTf
         },
         'terraform' => {
           'version_requirement' => nil
+        },
+        'yle_tf'    => {
+          'version_requirement' => nil
         }
       }.freeze
 

--- a/test/unit/yle_tf/action/verify_yle_tf_version_spec.rb
+++ b/test/unit/yle_tf/action/verify_yle_tf_version_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'yle_tf/action/verify_yle_tf_version'
+require 'yle_tf/config'
+require 'yle_tf/error'
+
+describe YleTf::Action::VerifyYleTfVersion do
+  subject(:action) { described_class.new(app) }
+
+  let(:app) { double('app', call: nil) }
+
+  describe '#call' do
+    let(:env) { { config: config } }
+    let(:config) do
+      YleTf::Config.new(
+        'yle_tf' => { 'version_requirement' => version_requirement }
+      )
+    end
+
+    let(:version) { '1.2.3' }
+
+    before do
+      stub_const('YleTf::VERSION', version)
+    end
+
+    context 'without configuration' do
+      let(:version_requirement) { nil }
+
+      it 'does not raise' do
+        expect { action.call(env) }.not_to raise_error
+      end
+
+      it 'calls next app' do
+        expect(app).to receive(:call).with(env)
+        action.call(env)
+      end
+    end
+
+    context 'with configuration' do
+      context 'with accepted version' do
+        let(:version_requirement) { '>= 1.1' }
+
+        it 'does not raise' do
+          expect { action.call(env) }.not_to raise_error
+        end
+
+        it 'calls next app' do
+          expect(app).to receive(:call).with(env)
+          action.call(env)
+        end
+      end
+
+      context 'with wrong version' do
+        let(:version_requirement) { '~> 1.0.4' }
+
+        it 'raises an error' do
+          expect(app).not_to receive(:call).with(env)
+
+          expect { action.call(env) }.to raise_error(
+            YleTf::Error, "YleTf version '1.2.3', '~> 1.0.4' required by config"
+          )
+        end
+      end
+    end
+  end
+end

--- a/test/unit/yle_tf/config/loader_spec.rb
+++ b/test/unit/yle_tf/config/loader_spec.rb
@@ -26,7 +26,8 @@ describe YleTf::Config::Loader do
           },
           'hooks'     => { 'pre' => [], 'post' => [] },
           'tfvars'    => {},
-          'terraform' => { 'version_requirement' => nil }
+          'terraform' => { 'version_requirement' => nil },
+          'yle_tf'    => { 'version_requirement' => nil }
         )
       end
     end
@@ -64,7 +65,8 @@ describe YleTf::Config::Loader do
           },
           'hooks'     => { 'pre' => [], 'post' => [] },
           'tfvars'    => { 'xxx' => 'yyy' },
-          'terraform' => { 'version_requirement' => nil }
+          'terraform' => { 'version_requirement' => nil },
+          'yle_tf'    => { 'version_requirement' => nil }
         )
       end
     end


### PR DESCRIPTION
In some configuration migrations (as would have been nice to have for v1.1), possible hook interface changes, etc., it can be useful to specify the minimum YleTf version in `tf.yaml`:

```yaml
yle_tf:
  version_requirement: ">= 1.2"
```