### PR TITLE
Drop support for Ruby v2.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
 Layout/AlignHash:
   EnforcedHashRocketStyle: table

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,9 @@ before_install:
 script: bundle exec rake "test[$TERRAFORM_VERSIONS]"
 
 rvm:
-  - 2.6.0
-  - 2.5.3
-  - 2.4.5
-  - 2.3.8
+  - 2.6.5
+  - 2.5.7
+  - 2.4.9
 
 env:
   global:

--- a/lib/yle_tf/cli.rb
+++ b/lib/yle_tf/cli.rb
@@ -50,7 +50,7 @@ class YleTf
           if TF_OPTIONS.include?(arg)
             @tf_options[key(arg)] = true
           else
-            STDERR.puts "Unknown option '#{arg}'"
+            warn "Unknown option '#{arg}'"
             @tf_command = 'help'
             @tf_env = 'error'
             break

--- a/yle_tf.gemspec
+++ b/yle_tf.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'guard-rspec', '~> 4.7'
-  spec.add_development_dependency 'rake', '~> 12.0'
+  spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.8'
   spec.add_development_dependency 'serverspec', '~> 2.41'
 end

--- a/yle_tf.gemspec
+++ b/yle_tf.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.executables   = ['tf']
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.3'
+  spec.required_ruby_version = '>= 2.4'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'guard-rspec', '~> 4.7'


### PR DESCRIPTION
Ruby 2.3 reached EOL on 2019-03-31:
https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/

- Require Ruby 2.4+ for the gem
- Update Ruby version matrix in Travis build
- Upgrade and fix Rubocop Rules for 2.4
- Upgrade Rake to 13.0