### PR TITLE
Update Terraform versions in acceptance tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ rvm:
 
 env:
   global:
-    - TERRAFORM_VERSIONS="0.11.11 0.10.8 0.9.11"
+    - TERRAFORM_VERSIONS="0.12.9 0.11.14 0.10.8 0.9.11"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Offers a command-line helper tool, `tf`
 
 YleTf requires Terraform which can be installed according to their [instructions](https://www.terraform.io/intro/getting-started/install.html). On MacOS (and OSX) you can use [Homebrew](https://brew.sh/). You can also easily install and manage multiple versions of Terraform with [homebrew-terraforms](https://github.com/Yleisradio/homebrew-terraforms).
 
+YleTf supports Terraform versions from 0.9 on. Tested versions range from 0.9 to 0.12".
+
 ## Installation
 
 YleTf can be installed as a gem:


### PR DESCRIPTION
Especially, add Terraform 0.12 to the test matrix.