### PR TITLE
Use `$HOME` instead of `~` in default .terraformrc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Compatibility:
 - Add Terraform 0.12 to the test matrix. Document the supported versions. ([GH-27](https://github.com/Yleisradio/yle_tf/pull/27))
 - Drop Ruby 2.3 from the test matrix. Document the supported versions. ([GH-28](https://github.com/Yleisradio/yle_tf/pull/28), [GH-26](https://github.com/Yleisradio/yle_tf/pull/26))
 
+Bug fixes:
+
+- Use `$HOME` instead of `~` in default .terraformrc ([GH-29](https://github.com/Yleisradio/yle_tf/pull/29))
+
 ## 1.2.0 / 2019-01-24
 
 New features:

--- a/lib/yle_tf/action/write_terraformrc_defaults.rb
+++ b/lib/yle_tf/action/write_terraformrc_defaults.rb
@@ -10,7 +10,7 @@ class YleTf
       RC_PATH = '~/.terraformrc'
 
       # Path of the plugin cache directory
-      DEFAULT_PLUGIN_CACHE_PATH = '~/.terraform.d/plugin-cache'
+      DEFAULT_PLUGIN_CACHE_PATH = '$HOME/.terraform.d/plugin-cache'
 
       def initialize(app)
         @app = app

--- a/test/acceptance/fixtures/terraformrc
+++ b/test/acceptance/fixtures/terraformrc
@@ -1,2 +1,2 @@
 disable_checkpoint = true
-plugin_cache_dir   = "~/.terraform.d/plugin-cache"
+plugin_cache_dir   = "$HOME/.terraform.d/plugin-cache"


### PR DESCRIPTION
The `~` might not be evaluated in all environments.