### PR TITLE
Fix compatibility with Ruby 2.7.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,9 +4,13 @@ AllCops:
 Gemspec/RequiredRubyVersion:
   Severity: warning
 
-Layout/AlignHash:
+Layout/HashAlignment:
   EnforcedHashRocketStyle: table
   EnforcedColonStyle: table
+
+Layout/LineLength:
+  Max: 100
+  Severity: warning
 
 Metrics/AbcSize:
   Max: 16
@@ -18,10 +22,6 @@ Metrics/BlockLength:
     - 'Rakefile'
 
 Metrics/ClassLength:
-  Severity: warning
-
-Metrics/LineLength:
-  Max: 100
   Severity: warning
 
 Metrics/MethodLength:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
 script: bundle exec rake "test[$TERRAFORM_VERSIONS]"
 
 rvm:
+  - 2.7.0
   - 2.6.5
   - 2.5.7
   - 2.4.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ rvm:
 
 env:
   global:
-    - TERRAFORM_VERSIONS="0.12.9 0.11.14 0.10.8 0.9.11"
+    - TERRAFORM_VERSIONS="0.12.19 0.11.14 0.10.8 0.9.11"

--- a/lib/yle_tf/action/terraform_init.rb
+++ b/lib/yle_tf/action/terraform_init.rb
@@ -35,7 +35,7 @@ class YleTf
         backend.configure
 
         Logger.debug('Initializing Terraform')
-        YleTf::System.cmd('terraform', 'init', *TF_CMD_ARGS, TF_CMD_OPTS)
+        YleTf::System.cmd('terraform', 'init', *TF_CMD_ARGS, **TF_CMD_OPTS)
       end
 
       def backend(config)

--- a/lib/yle_tf/config.rb
+++ b/lib/yle_tf/config.rb
@@ -20,7 +20,7 @@ class YleTf
       }
 
       config = Loader.new(opts).load
-      new(config, opts)
+      new(config, **opts)
     end
 
     attr_reader :config, :tf_env, :module_dir

--- a/lib/yle_tf/config/loader.rb
+++ b/lib/yle_tf/config/loader.rb
@@ -91,7 +91,7 @@ class YleTf
 
       def migrate_old_config(config, **opts)
         task('  -> Migrating') do
-          Config::Migration.migrate_old_config(config, opts)
+          Config::Migration.migrate_old_config(config, **opts)
         end
       end
 

--- a/lib/yle_tf/system.rb
+++ b/lib/yle_tf/system.rb
@@ -47,7 +47,7 @@ class YleTf
 
     def self.read_cmd(*args, **opts)
       buffer = StringIO.new
-      cmd(*args, opts.merge(stdout: buffer))
+      cmd(*args, **opts.merge(stdout: buffer))
       buffer.string
     end
 

--- a/lib/yle_tf/system/io_handlers.rb
+++ b/lib/yle_tf/system/io_handlers.rb
@@ -108,7 +108,7 @@ class YleTf
         while (data = source.readpartial(BLOCK_SIZE))
           target.write(data)
         end
-      rescue EOFError # rubocop:disable Lint/HandleExceptions
+      rescue EOFError # rubocop:disable Lint/SuppressedException
         # All read
       rescue IOError => e
         YleTf::Logger.debug e.full_message

--- a/test/unit/yle_tf/action/load_config_spec.rb
+++ b/test/unit/yle_tf/action/load_config_spec.rb
@@ -13,7 +13,7 @@ describe YleTf::Action::LoadConfig do
     let(:env) { { tf_env: tf_env, config: config } }
     let(:tf_env) { 'myenv' }
 
-    let(:dummy_config) { YleTf::Config.new('foo' => 'bar') }
+    let(:dummy_config) { YleTf::Config.new({ 'foo' => 'bar' }) }
 
     context 'when config not yet loaded' do
       let(:config) { nil }

--- a/test/unit/yle_tf/action/verify_terraform_version_spec.rb
+++ b/test/unit/yle_tf/action/verify_terraform_version_spec.rb
@@ -19,9 +19,13 @@ describe YleTf::Action::VerifyTerraformVersion do
 
     let(:env) { { config: config } }
     let(:config) do
-      YleTf::Config.new('terraform' => {
-                          'version_requirement' => config_requirement
-                        })
+      YleTf::Config.new(
+        {
+          'terraform' => {
+            'version_requirement' => config_requirement
+          }
+        }
+      )
     end
     let(:config_requirement) { nil }
 

--- a/test/unit/yle_tf/action/verify_yle_tf_version_spec.rb
+++ b/test/unit/yle_tf/action/verify_yle_tf_version_spec.rb
@@ -13,7 +13,9 @@ describe YleTf::Action::VerifyYleTfVersion do
     let(:env) { { config: config } }
     let(:config) do
       YleTf::Config.new(
-        'yle_tf' => { 'version_requirement' => version_requirement }
+        {
+          'yle_tf' => { 'version_requirement' => version_requirement }
+        }
       )
     end
 

--- a/test/unit/yle_tf/config/migration_spec.rb
+++ b/test/unit/yle_tf/config/migration_spec.rb
@@ -10,7 +10,7 @@ describe YleTf::Config::Migration do
       allow(YleTf::Logger).to receive(:warn)
     end
 
-    subject { described_class.migrate_old_config(config, opts) }
+    subject { described_class.migrate_old_config(config, **opts) }
     let(:config) { { 'backend' => backend_config } }
     let(:opts) { { source: 'test' } }
 

--- a/test/unit/yle_tf/config_spec.rb
+++ b/test/unit/yle_tf/config_spec.rb
@@ -74,7 +74,7 @@ describe YleTf::Config do
 
           it 'does not warn' do
             expect(YleTf::Logger).not_to receive(:warn)
-            begin fetch; rescue YleTf::Error; end # rubocop:disable Lint/HandleExceptions
+            begin fetch; rescue YleTf::Error; end # rubocop:disable Lint/SuppressedException
           end
         end
 
@@ -83,7 +83,7 @@ describe YleTf::Config do
 
           it 'warns' do
             expect(YleTf::Logger).to receive(:warn)
-            begin fetch; rescue YleTf::Error; end # rubocop:disable Lint/HandleExceptions
+            begin fetch; rescue YleTf::Error; end # rubocop:disable Lint/SuppressedException
           end
         end
       end

--- a/test/unit/yle_tf/config_spec.rb
+++ b/test/unit/yle_tf/config_spec.rb
@@ -4,7 +4,7 @@ require 'yle_tf/config'
 require 'yle_tf/logger'
 
 describe YleTf::Config do
-  subject(:config) { described_class.new(config_hash, opts) }
+  subject(:config) { described_class.new(config_hash, **opts) }
   let(:config_hash) { {} }
   let(:opts) { {} }
 

--- a/yle_tf.gemspec
+++ b/yle_tf.gemspec
@@ -33,6 +33,11 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3'
 
+  spec.add_runtime_dependency 'thwait', '~> 0.1.0'
+
+  # TODO: remove when thwait releases v>0.1.0
+  spec.add_runtime_dependency 'e2mmap', '~> 0.1.0'
+
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'guard-rspec', '~> 4.7'
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
EDIT: I rearranged and amended to the original PR to fix the tests etc. - @tmatilai 

### Fixes for Ruby 2.7

* https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/
* Add missing dependencies for Ruby 2.7
    - Ruby 2.7.0 no longer includes `thwait` and `e2mmap` as system libraries
    - `e2mmap` is a (missing) dependency of `thwait`, so we must declare it until the next thwait release.no longer includes thwait and e2mmap as system libraries
* Fix keyword argument warnings for Ruby 2.7
    - Automatic conversion of keyword arguments and positional arguments is deprecated, and conversion will be removed in Ruby 3.

### Test updates

* Add Ruby 2.7.0 to the test matrix
* Update tested Terraform versions
* Update Rubocop configuration for recent versions