### PR TITLE
Symlink `errored.tfstate` from run dir to module dir

### DIFF
--- a/lib/yle_tf/action/terraform_init.rb
+++ b/lib/yle_tf/action/terraform_init.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'pathname'
+
 require 'yle_tf/logger'
 require 'yle_tf/plugin'
 require 'yle_tf/system'
@@ -14,13 +16,14 @@ class YleTf
         stdout: :debug                            # Hide the output to the debug level
       }.freeze
 
+      attr_reader :config
+
       def initialize(app)
         @app = app
       end
 
       def call(env)
-        config = env[:config]
-        backend = backend(config)
+        @config = env[:config]
 
         Logger.info('Initializing Terraform')
         Logger.debug("Backend configuration: #{backend}")
@@ -34,16 +37,33 @@ class YleTf
         Logger.debug('Configuring the backend')
         backend.configure
 
+        Logger.debug('Symlinking errored.tfstate')
+        symlink_errored_tfstate
+
         Logger.debug('Initializing Terraform')
         YleTf::System.cmd('terraform', 'init', *TF_CMD_ARGS, **TF_CMD_OPTS)
       end
 
-      def backend(config)
+      def backend
+        @backend ||= find_backend
+      end
+
+      def find_backend
         backend_type = config.fetch('backend', 'type').downcase
         backend_proc = Plugin.manager.backends[backend_type]
 
         klass = backend_proc.call
         klass.new(config)
+      end
+
+      def symlink_errored_tfstate
+        local_path = Pathname.pwd.join('errored.tfstate')
+        remote_path = config.module_dir.join('errored.tfstate')
+
+        # Remove the possibly copied old file
+        local_path.unlink if local_path.exist?
+
+        local_path.make_symlink(remote_path)
       end
     end
   end

--- a/test/unit/yle_tf/action/terraform_init_spec.rb
+++ b/test/unit/yle_tf/action/terraform_init_spec.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require 'fileutils'
+require 'pathname'
+require 'tmpdir'
+
 require 'yle_tf/action/terraform_init'
 require 'yle_tf/config'
 require 'yle_tf/system'
@@ -11,20 +15,33 @@ describe YleTf::Action::TerraformInit do
 
   describe '#call' do
     let(:env) { { config: config } }
-    let(:config) do
-      YleTf::Config.new(
-        'backend' => { 'type' => 'foo', 'foo' => {} }
-      )
-    end
+    let(:config) { instance_double('YleTf::Config') }
 
     let(:backend) { instance_double('YleTf::Backend') }
+
+    let(:module_dir) { Pathname.new(module_dir_path) }
+    let(:module_dir_path) { File.expand_path('../../fixtures/empty', __dir__) }
+
+    let(:errored_tfstate) { Pathname.new('errored.tfstate') }
 
     before do
       allow(action).to receive(:backend) { backend }
       allow(backend).to receive(:configure) { nil }
+      allow(config).to receive(:module_dir) { module_dir }
 
       allow(YleTf::System).to receive(:cmd)
       allow(YleTf::Logger).to receive(:info)
+
+      # Run in a tmpdir as a symlink will be created
+      @orig_pwd = Dir.pwd
+      @tmpdir = Dir.mktmpdir
+      Dir.chdir(@tmpdir)
+    end
+
+    after do
+      # Remove the tmpdir
+      Dir.chdir(@orig_pwd)
+      FileUtils.rm_rf(@tmpdir, secure: true)
     end
 
     it 'does not raise' do
@@ -44,6 +61,24 @@ describe YleTf::Action::TerraformInit do
     it 'initializes Terraform' do
       expect(YleTf::System).to receive(:cmd).with('terraform', 'init', any_args)
       action.call(env)
+    end
+
+    it 'creates symlink to errored.tfstate' do
+      action.call(env)
+      expect(errored_tfstate).to be_symlink
+      expect(errored_tfstate.readlink).to eq(module_dir.join('errored.tfstate'))
+    end
+
+    context 'when old errored.tfstate exists' do
+      before do
+        FileUtils.touch(errored_tfstate)
+      end
+
+      it 'replaces it with a symlink' do
+        action.call(env)
+        expect(errored_tfstate).to be_symlink
+        expect(errored_tfstate.readlink).to eq(module_dir.join('errored.tfstate'))
+      end
     end
   end
 end

--- a/test/unit/yle_tf/action/terraform_init_spec.rb
+++ b/test/unit/yle_tf/action/terraform_init_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'yle_tf/action/terraform_init'
+require 'yle_tf/config'
+require 'yle_tf/system'
+
+describe YleTf::Action::TerraformInit do
+  subject(:action) { described_class.new(app) }
+
+  let(:app) { double('app', call: nil) }
+
+  describe '#call' do
+    let(:env) { { config: config } }
+    let(:config) do
+      YleTf::Config.new(
+        'backend' => { 'type' => 'foo', 'foo' => {} }
+      )
+    end
+
+    let(:backend) { instance_double('YleTf::Backend') }
+
+    before do
+      allow(action).to receive(:backend) { backend }
+      allow(backend).to receive(:configure) { nil }
+
+      allow(YleTf::System).to receive(:cmd)
+      allow(YleTf::Logger).to receive(:info)
+    end
+
+    it 'does not raise' do
+      expect { action.call(env) }.not_to raise_error
+    end
+
+    it 'calls next app' do
+      expect(app).to receive(:call).with(env)
+      action.call(env)
+    end
+
+    it 'configures the backend' do
+      expect(backend).to receive(:configure)
+      action.call(env)
+    end
+
+    it 'initializes Terraform' do
+      expect(YleTf::System).to receive(:cmd).with('terraform', 'init', any_args)
+      action.call(env)
+    end
+  end
+end


### PR DESCRIPTION
Terraform stores state in `errored.tfstate` if it fails to persist a state to a backend. As YleTf runs in a temporary directory, it would be lost and recovery gets complicated.

So make a symlink to the module dir to store an errored tfstate.

Also add unit tests for the `TerraformInit` class.