### PR TITLE
Update test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
 script: bundle exec rake "test[$TERRAFORM_VERSIONS]"
 
 rvm:
+  - 3.0.0
   - 2.7.2
   - 2.6.6
   - 2.5.8
@@ -21,4 +22,4 @@ rvm:
 
 env:
   global:
-    - TERRAFORM_VERSIONS="0.13.4 0.12.29 0.11.14 0.10.8 0.9.11"
+    - TERRAFORM_VERSIONS="0.14.3 0.13.5 0.12.29 0.11.14"

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Offers a command-line helper tool, `tf`
 
 YleTf requires Terraform which can be installed according to their [instructions](https://www.terraform.io/intro/getting-started/install.html). On MacOS (and OSX) you can use [Homebrew](https://brew.sh/). You can also easily install and manage multiple versions of Terraform with [homebrew-terraforms](https://github.com/Yleisradio/homebrew-terraforms).
 
-YleTf supports Terraform versions from 0.9 on. Tested versions range from 0.9 to 0.13.
+YleTf supports Terraform versions from 0.9 on. Tested versions range from 0.11 to 0.14.
 
-YleTf also requires Ruby 2.3 or newer. Tested versions range from 2.4 to 2.7.
+YleTf requires Ruby 2.3 or newer. Tested versions range from 2.4 to 3.0.
 
 ## Installation
 


### PR DESCRIPTION
Add Ruby 3.0 and Terraform 0.14 to the test matrix.

Stop testing Terraform versions older than 0.11 to save Travis cycles.
We still support versions from 0.9, although user base for such old
versions should be small.