### PR TITLE
Don't try to list all Terraform commands

### DIFF
--- a/lib/yle_tf_plugins/commands/help/command.rb
+++ b/lib/yle_tf_plugins/commands/help/command.rb
@@ -2,7 +2,6 @@
 
 require 'optparse'
 
-require 'yle_tf/system'
 require 'yle_tf/plugin'
 
 module YleTfPlugins
@@ -20,18 +19,17 @@ module YleTfPlugins
           o.banner = 'Usage: tf <environment> <command> [<args>]'
           o.separator ''
           o.separator 'YleTf options:'
-          o.on('-h', '--help', 'Prints this help')
+          o.on('-h', '--help',    'Prints this help')
           o.on('-v', '--version', 'Prints the version information')
-          o.on('--debug', 'Print debug information')
-          o.on('--no-color', 'Do not output with colors')
-          o.on('--no-hooks', 'Do not run any hooks')
-          o.on('--only-hooks', 'Only run the hooks')
+          o.on('--debug',         'Print debug information')
+          o.on('--no-color',      'Do not output with colors')
+          o.on('--no-hooks',      'Do not run any hooks')
+          o.on('--only-hooks',    'Only run the hooks')
           o.separator ''
-          o.separator 'Special tf commands:'
+          o.separator 'Special YleTf commands:'
           o.separator tf_command_help
           o.separator ''
-          o.separator 'Terraform commands:'
-          o.separator terraform_help
+          o.separator 'Run `terraform -help` to get list of all Terraform commands.'
         end
       end
       # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
@@ -48,17 +46,6 @@ module YleTfPlugins
         YleTf::Plugin.manager.commands.sort.map do |command, data|
           "    #{command.ljust(18)} #{data[:synopsis]}"
         end
-      end
-
-      def terraform_help
-        on_error = proc do |exit_code|
-          # exit_code is nil if the command was not found
-          # Ignore other exit codes, as older Terraform versions return
-          # non-zero exit codes for the help.
-          return '    [Terraform not found]' if exit_code.nil?
-        end
-        help = YleTf::System.read_cmd('terraform', '--help', error_handler: on_error)
-        help.lines.grep(/^    /)
       end
     end
   end


### PR DESCRIPTION
The output format changes between Terraform versions. The list is also really long. So guide the user to call `terraform -help` to get it.

Fixes #37