### PR TITLE
Write terraformrc only if it doesn't exist

### DIFF
--- a/lib/yle_tf/action/write_terraformrc_defaults.rb
+++ b/lib/yle_tf/action/write_terraformrc_defaults.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'fileutils'
+require 'pathname'
+
 require 'yle_tf/logger'
 
 class YleTf
@@ -10,45 +12,58 @@ class YleTf
       RC_PATH = '~/.terraformrc'
 
       # Path of the plugin cache directory
-      DEFAULT_PLUGIN_CACHE_PATH = '$HOME/.terraform.d/plugin-cache'
+      DEFAULT_PLUGIN_CACHE_PATH = '~/.terraform.d/plugin-cache'
 
       def initialize(app)
         @app = app
       end
 
       def call(env)
-        Logger.debug("Writing default configuration to '#{RC_PATH}'")
-        open_rc_file do |rc_file|
-          keys = existing_keys(rc_file)
-
-          configure_checkpoint(rc_file) if !keys.include?('disable_checkpoint')
-          configure_plugin_cache_dir(rc_file) if !keys.include?('plugin_cache_dir')
+        if rc_file.exist?
+          Logger.debug("Terraform configuration file '#{RC_PATH}' already exists")
+          if !existing_keys.include?('plugin_cache_dir')
+            Logger.warn("'plugin_cache_dir' not configured in '#{RC_PATH}'")
+          end
+        else
+          Logger.debug("Writing default configuration to '#{RC_PATH}'")
+          write_default_config
         end
 
         @app.call(env)
       end
 
-      def open_rc_file(&block)
-        File.open(File.expand_path(RC_PATH), 'a+', &block)
+      def rc_file
+        @rc_file ||= Pathname.new(RC_PATH).expand_path
       end
 
-      def existing_keys(rc_file)
-        [].tap do |keys|
-          rc_file.each_line do |line|
+      def existing_keys
+        @existing_keys ||= [].tap do |keys|
+          rc_file.readlines.each do |line|
+            # The matcher is a bit naive, but enough for out use
             keys << Regexp.last_match(1) if line =~ /^(.+?)[ \t]*=/
           end
         end
       end
 
-      def configure_checkpoint(rc_file)
-        Logger.info("Disabling Terraform upgrade and security bulletin checks by '#{RC_PATH}'")
-
-        rc_file.puts('disable_checkpoint = true')
+      def write_default_config
+        rc_file.open('w') do |rc_file|
+          configure_checkpoint(rc_file)
+          configure_plugin_cache_dir(rc_file)
+        end
       end
 
-      def configure_plugin_cache_dir(rc_file)
+      def configure_checkpoint(file)
+        Logger.info("Disabling Terraform upgrade and security bulletin checks by '#{RC_PATH}'")
+
+        file.puts('disable_checkpoint = true')
+      end
+
+      def configure_plugin_cache_dir(file)
         Logger.info("Configuring global Terraform plugin cache by '#{RC_PATH}'")
-        rc_file.puts("plugin_cache_dir   = \"#{DEFAULT_PLUGIN_CACHE_PATH}\"")
+        # Replace `~` with `$HOME` as it is not expanded correctly in all architectures.
+        # Can't use `$HOME` in the constant though, as it won't be expanded by
+        # `expand_path` below. Can't win this game.
+        file.puts("plugin_cache_dir   = \"#{DEFAULT_PLUGIN_CACHE_PATH.sub(/^~/, '$HOME')}\"")
 
         dir = File.expand_path(DEFAULT_PLUGIN_CACHE_PATH)
         return if File.directory?(dir)


### PR DESCRIPTION
Do not force the settings if the config file already exist.

Still warn about missing `plugin_cache_dir` setting as it might slow down YleTf execution by loading the plugins every time to the temporary directory.

Also fix the plugin cache directory existence check that was accidentally broken in #29.
Fixes: #34