### PR TITLE
Support encrypting file backend states

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ variable "ami" {
 
 variable "instance_type" {
   description = "Instance type to use"
-  default = "t2.micro"
+  default     = "t2.micro"
 }
 ```
 
@@ -428,7 +428,7 @@ hooks:
 
 Configure where Terraform [remote state](https://www.terraform.io/docs/state/remote.html) is stored. See the Terraform documentation for [backends](https://www.terraform.io/docs/backends/) and especially [types](https://www.terraform.io/docs/backends/types/) for backend specific configuration options.
 
-_Note:_ the `local` backend type is not supported due to YleTf initialization process and use of temporary directory. Use the default `file` type instead, which makes a symlink to the state file in the working directory.
+_Note:_ the `local` backend type is not supported due to YleTf initialization process and use of temporary directory. Use the default `file` type instead, which makes a symlink to the state file (by default in the working directory).
 
 ```yaml
 type: <type>        # Backend type where the Terraform state is stored, e.g. `file` (local file), `s3`, `swift`.
@@ -458,6 +458,18 @@ backend:
     # Use the sanitized directory name right after the "src/" directory as part of the bucket name.
     bucket: 'terraform-state-<%= @module_dir.match(%r{.*/src/([^/]+)/})[1].downcase.tr("^a-z0-9", "-") %>-<%= @env %>'
     encrypt: true
+```
+
+Experimental encryption of the `file` backend (by default using [sops](https://github.com/mozilla/sops#readme), so maybe add `.sops.yaml` to configure it):
+
+```yaml
+backend:
+  type: file
+  file:
+    encrypt: true
+    ## The default commands:
+    #encrypt_command: sops --encrypt --input-type binary --output-type binary --output "{{TO}}" "{{FROM}}"
+    #decrypt_command: sops --decrypt --input-type binary --output-type binary --output "{{TO}}" "{{FROM}}"
 ```
 
 #### Terraform

--- a/lib/yle_tf/action/terraform_init.rb
+++ b/lib/yle_tf/action/terraform_init.rb
@@ -30,7 +30,7 @@ class YleTf
         Logger.info('Initializing Terraform')
         Logger.debug("Backend configuration: #{backend}")
 
-        init_dir(backend)
+        init_dir
 
         if env[:tf_command] == 'init'
           # Skip initializing Terraform here, as it will be done by the
@@ -42,14 +42,21 @@ class YleTf
           store_terraform_lock
           @app.call(env)
         end
+
+        tear_down
       end
 
-      def init_dir(backend)
+      def init_dir
         Logger.debug('Configuring the backend')
         backend.configure
 
         Logger.debug('Symlinking errored.tfstate')
         symlink_to_module_dir('errored.tfstate')
+      end
+
+      def tear_down
+        Logger.debug('Tearing down backend')
+        backend.tear_down
       end
 
       def init_terraform

--- a/lib/yle_tf/backend.rb
+++ b/lib/yle_tf/backend.rb
@@ -30,6 +30,11 @@ class YleTf
       File.write(BACKEND_CONFIG_FILE, JSON.pretty_generate(data))
     end
 
+    # Tear down the backend
+    def tear_down
+      # Nothing to do by default
+    end
+
     # Returns the backend configuration as a `Hash` for Terraform
     def to_h
       { type => backend_specific_config }

--- a/lib/yle_tf/config/defaults.rb
+++ b/lib/yle_tf/config/defaults.rb
@@ -13,7 +13,10 @@ class YleTf
         'backend'   => {
           'type' => 'file',
           'file' => {
-            'path' => '<%= @module %>_<%= @env %>.tfstate'
+            'path'            => '<%= @module %>_<%= @env %>.tfstate',
+            'encrypt'         => false,
+            'encrypt_command' => 'sops --encrypt --input-type binary --output-type binary --output "{{TO}}" "{{FROM}}"',
+            'decrypt_command' => 'sops --decrypt --input-type binary --output-type binary --output "{{TO}}" "{{FROM}}"'
           },
           's3'   => {
             'key' => '<%= @module %>_<%= @env %>.tfstate'

--- a/lib/yle_tf_plugins/backends/file/backend.rb
+++ b/lib/yle_tf_plugins/backends/file/backend.rb
@@ -1,24 +1,83 @@
 # frozen_string_literal: true
 
+require 'fileutils'
 require 'pathname'
+require 'shellwords'
+
 require 'yle_tf/backend'
 require 'yle_tf/logger'
+require 'yle_tf/system'
 
 module YleTfPlugins
   module Backends
     module File
       class Backend < YleTf::Backend
-        # Symlinks local "terraform.tfstate" to the specified path
         def configure
-          YleTf::Logger.info("Symlinking state to '#{tfstate_path}'")
-          local_path = Pathname.pwd.join('terraform.tfstate')
-          local_path.make_symlink(tfstate_path)
+          if !encrypt?
+            create_tfstate(tfstate_path)
+            symlink_tfstate
+          elsif tfstate_path.exist?
+            decrypt_tfstate
+          end
+        end
 
-          tfstate_path.write(tfstate_template, perm: 0o644) if !tfstate_path.exist?
+        def tear_down
+          encrypt_tfstate if encrypt? && local_tfstate_path.exist?
+        end
+
+        def create_tfstate(path)
+          return if path.exist?
+
+          YleTf::Logger.debug('Creating state file')
+          path.write(tfstate_template, perm: 0o644)
+        end
+
+        def symlink_tfstate
+          YleTf::Logger.info("Symlinking state to '#{tfstate_path}'")
+          local_tfstate_path.make_symlink(tfstate_path)
+        end
+
+        def encrypt?
+          config.fetch('backend', type, 'encrypt')
+        end
+
+        def decrypt_tfstate
+          YleTf::Logger.info("Decrypting state from '#{tfstate_path}'")
+
+          cmd = config.fetch('backend', type, 'decrypt_command')
+          cmd.gsub!('{{FROM}}', tfstate_path.to_s)
+          cmd.gsub!('{{TO}}', local_tfstate_path.to_s)
+
+          # Split the command to have nicer logs
+          YleTf::System.cmd(*Shellwords.split(cmd))
+        end
+
+        def encrypt_tfstate
+          YleTf::Logger.info("Encrypting state to '#{tfstate_path}'")
+
+          cmd = config.fetch('backend', type, 'encrypt_command')
+          cmd.gsub!('{{FROM}}', local_tfstate_path.to_s)
+          cmd.gsub!('{{TO}}', tfstate_path.to_s)
+
+          YleTf::System.cmd(*Shellwords.split(cmd),
+                            error_handler: method(:on_encrypt_error))
+        end
+
+        def on_encrypt_error(_exit_code, error)
+          plain_tfstate_path = "#{tfstate_path}.plaintext"
+
+          YleTf::Logger.warn("Copying unencrypted state to '#{plain_tfstate_path}'")
+          FileUtils.cp(local_tfstate_path.to_s, plain_tfstate_path)
+
+          raise error
         end
 
         def tfstate_path
-          @tfstate_path ||= config.module_dir.join(config.fetch('backend', 'file', 'path'))
+          @tfstate_path ||= config.module_dir.join(config.fetch('backend', type, 'path'))
+        end
+
+        def local_tfstate_path
+          @local_tfstate_path ||= Pathname.pwd.join('terraform.tfstate')
         end
 
         def tfstate_template

--- a/test/unit/yle_tf/action/terraform_init_spec.rb
+++ b/test/unit/yle_tf/action/terraform_init_spec.rb
@@ -27,7 +27,8 @@ describe YleTf::Action::TerraformInit do
 
     before do
       allow(action).to receive(:backend) { backend }
-      allow(backend).to receive(:configure) { nil }
+      allow(backend).to receive(:configure)
+      allow(backend).to receive(:tear_down)
       allow(config).to receive(:module_dir) { module_dir }
 
       allow(YleTf::System).to receive(:cmd)
@@ -57,6 +58,11 @@ describe YleTf::Action::TerraformInit do
 
     it 'configures the backend' do
       expect(backend).to receive(:configure)
+      action.call(env)
+    end
+
+    it 'tears down the backend' do
+      expect(backend).to receive(:tear_down)
       action.call(env)
     end
 

--- a/test/unit/yle_tf/config/loader_spec.rb
+++ b/test/unit/yle_tf/config/loader_spec.rb
@@ -17,19 +17,9 @@ describe YleTf::Config::Loader do
     let(:module_dir_path) { '/hopefully/non-existing/test-module' }
 
     context 'with default config' do
-      it do
-        is_expected.to eq(
-          'backend'   => {
-            'type' => 'file',
-            'file' => { 'path' => 'test-module_unit-tests.tfstate' },
-            's3'   => { 'key' => 'test-module_unit-tests.tfstate' }
-          },
-          'hooks'     => { 'pre' => [], 'post' => [] },
-          'tfvars'    => {},
-          'terraform' => { 'version_requirement' => nil },
-          'yle_tf'    => { 'version_requirement' => nil }
-        )
-      end
+      its(%w[backend type]) { is_expected.to eq('file') }
+      its(%w[backend file path]) { is_expected.to eq('test-module_unit-tests.tfstate') }
+      its(%w[backend s3 key]) { is_expected.to eq('test-module_unit-tests.tfstate') }
     end
 
     context 'with plugin and file configs' do
@@ -56,18 +46,11 @@ describe YleTf::Config::Loader do
         expect(loader).to receive(:plugins) { [test_plugin] }
         expect(loader).to receive(:config_files) { [config_file] }
 
-        is_expected.to eq(
-          'backend'   => {
-            'type' => 'foo',
-            'file' => { 'path' => 'test-module_unit-tests.tfstate' },
-            's3'   => { 'key' => 'test-module_unit-tests.tfstate' },
-            'foo'  => { 'bar' => 'from_file' }
-          },
-          'hooks'     => { 'pre' => [], 'post' => [] },
-          'tfvars'    => { 'xxx' => 'yyy' },
-          'terraform' => { 'version_requirement' => nil },
-          'yle_tf'    => { 'version_requirement' => nil }
-        )
+        expect(subject['backend']['type']).to eq('foo')
+        expect(subject['backend']['s3']['key']).to eq('test-module_unit-tests.tfstate')
+        expect(subject['backend']['foo']).to eq({ 'bar' => 'from_file' })
+        expect(subject['backend']['foo']).to eq({ 'bar' => 'from_file' })
+        expect(subject['tfvars']['xxx']).to eq('yyy')
       end
     end
   end


### PR DESCRIPTION
Add support for automatically encrypting and decrypting the state file when using the (default) `file` backend. The feature is still experimental as functionality might change after gaining experience and feedback.

If encryption is enabled, instead of symlinking, the state file is decrypted from the `path` to the temporary working directory just before initializing Terraform, and decrypted back after running the actual command.

If the encryption fails, the uncrypted state file is copied to "`path`.plaintext" for the user to encrypt manually.

By default the encryption is done using [sops](https://github.com/mozilla/sops#readme), but the whole file is encrypted instead of just leaf values, as the whole content is anyway encrypted on every run.
Sops can be configured further (e.g. the keys) with `.sops.yaml`.

The actual commands are also configurable, for example:

```yaml
backend:
  file:
    encrypt: true
    encrypt_command: sh -c 'tr "A-Za-z" "N-ZA-Mn-za-m" <"{{FROM}}" >"{{TO}}"'
    decrypt_command: sh -c 'tr "A-Za-z" "N-ZA-Mn-za-m" <"{{FROM}}" >"{{TO}}"'
```