### PR TITLE
[logger] terraform supports TF_LOG=TRACE

### DIFF
--- a/lib/yle_tf/logger.rb
+++ b/lib/yle_tf/logger.rb
@@ -30,6 +30,7 @@ class YleTf
 
     def self.log_level
       (ENV['TF_DEBUG'] && 'DEBUG') || \
+        (ENV['TF_LOG'] == 'TRACE' && 'DEBUG') || \
         ENV['TF_LOG'] || \
         'INFO'
     end


### PR DESCRIPTION
With ruby's logger best alternative would be to map TRACE into DEBUG.
References:
- https://ruby-doc.org/stdlib-3.0.0/libdoc/logger/rdoc/Logger.html
- https://www.terraform.io/docs/internals/debugging.html

Work-around:
Define TF_DEBUG=1 TF_LOG=TRACE.
This way yle_tf will respond to TF_DEBUG and TF_LOG gets passed to terraform as it is.