### PR TITLE
[tf_hook_output_logger] Encode string so that String.sub() works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## 1.4.1 / _Not released yet_
 
+Compatibility:
+
+- Handle TF_LOG=TRACE in similar fashion as DEBUG ([GH-41](https://github.com/Yleisradio/yle_tf/pull/41/))
+- Add Terrafrom 1.0 to tested versions. ([GH-43](https://github.com/Yleisradio/yle_tf/pull/43))
+
+Bugfixes:
+
+- Encode terraform hooks output into UTF-8. Previously it crashed in String.sub method. ([GH-42](https://github.com/Yleisradio/yle_tf/pull/42))
 
 ## 1.4.0 / 2021-01-21
 

--- a/lib/yle_tf/system/tf_hook_output_logger.rb
+++ b/lib/yle_tf/system/tf_hook_output_logger.rb
@@ -13,7 +13,7 @@ class YleTf
       def log(progname, line)
         # Remove `[<progname>] ` prefix from the output line.
         # This is mostly for backwards compatibility in Yle.
-        line.sub!(/^\[#{progname}\] /, '')
+        line = line.encode('utf-8').sub(/^\[#{progname}\] /, '')
 
         level, line = line_level(line)
 


### PR DESCRIPTION
To avoid this type of situations:
```
#<Thread:0x000055c4570a5908 /usr/yle-aws-tools/.gems/ruby/2.7.0/gems/yle_tf-1.4.0/lib/yle_tf/system/output_logger.rb:17 run> terminated with exception (report_on_exception is true):
Traceback (most recent call last):
	4: from /usr/yle-aws-tools/.gems/ruby/2.7.0/gems/yle_tf-1.4.0/lib/yle_tf/system/output_logger.rb:19:in `block in call'
	3: from /usr/yle-aws-tools/.gems/ruby/2.7.0/gems/yle_tf-1.4.0/lib/yle_tf/system/output_logger.rb:19:in `each'
	2: from /usr/yle-aws-tools/.gems/ruby/2.7.0/gems/yle_tf-1.4.0/lib/yle_tf/system/output_logger.rb:19:in `block (2 levels) in call'
	1: from /usr/yle-aws-tools/.gems/ruby/2.7.0/gems/yle_tf-1.4.0/lib/yle_tf/system/tf_hook_output_logger.rb:16:in `log'
/usr/yle-aws-tools/.gems/ruby/2.7.0/gems/yle_tf-1.4.0/lib/yle_tf/system/tf_hook_output_logger.rb:16:in `sub!': invalid byte sequence in US-ASCII (ArgumentError)
```