### PR TITLE
[tf_hook_output_logger] Use force_encoding instead of encoding.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ Compatibility:
 
 - Handle TF_LOG=TRACE in similar fashion as DEBUG ([GH-41](https://github.com/Yleisradio/yle_tf/pull/41/))
 - Add Terrafrom 1.0 to tested versions. ([GH-43](https://github.com/Yleisradio/yle_tf/pull/43))
-
+-
 Bugfixes:
 
-- Encode terraform hooks output into UTF-8. Previously it crashed in String.sub method. ([GH-42](https://github.com/Yleisradio/yle_tf/pull/42))
+- Interpret terraform hooks output as UTF-8. ([GH-42](https://github.com/Yleisradio/yle_tf/pull/42) & [GH-44](https://github.com/Yleisradio/yle_tf/pull/44))
 
 ## 1.4.0 / 2021-01-21
 

--- a/lib/yle_tf/system/tf_hook_output_logger.rb
+++ b/lib/yle_tf/system/tf_hook_output_logger.rb
@@ -15,7 +15,7 @@ class YleTf
         # This is mostly for backwards compatibility in Yle.
         level = "INFO".downcase.to_sym
         begin
-          newline = line.encode(Encoding::UTF_8).sub(/^\[#{progname}\] /, '')
+          newline = line.force_encoding(Encoding::UTF_8).sub(/^\[#{progname}\] /, '')
           level, line = line_level(newline)
         rescue ArgumentError, Encoding::InvalidByteSequenceError => e
           YleTf::Logger.warn "Caught exception #{e} with #{line}"

--- a/lib/yle_tf/system/tf_hook_output_logger.rb
+++ b/lib/yle_tf/system/tf_hook_output_logger.rb
@@ -13,9 +13,12 @@ class YleTf
       def log(progname, line)
         # Remove `[<progname>] ` prefix from the output line.
         # This is mostly for backwards compatibility in Yle.
-        line = line.encode('utf-8').sub(/^\[#{progname}\] /, '')
-
-        level, line = line_level(line)
+        begin
+          newline = line.encode('utf-8').sub(/^\[#{progname}\] /, '')
+        rescue Encoding::InvalidByteSequenceError
+          newline = line
+        end
+        level, line = line_level(newline)
 
         YleTf::Logger.public_send(level, progname) { line }
       end

--- a/lib/yle_tf/system/tf_hook_output_logger.rb
+++ b/lib/yle_tf/system/tf_hook_output_logger.rb
@@ -17,7 +17,7 @@ class YleTf
         begin
           newline = line.force_encoding(Encoding::UTF_8).sub(/^\[#{progname}\] /, '')
           level, line = line_level(newline)
-        rescue ArgumentError, Encoding::InvalidByteSequenceError => e
+        rescue ArgumentError => e
           YleTf::Logger.warn "Caught exception #{e} with #{line}"
         end
 

--- a/lib/yle_tf/system/tf_hook_output_logger.rb
+++ b/lib/yle_tf/system/tf_hook_output_logger.rb
@@ -13,12 +13,13 @@ class YleTf
       def log(progname, line)
         # Remove `[<progname>] ` prefix from the output line.
         # This is mostly for backwards compatibility in Yle.
+        level = "INFO"
         begin
           newline = line.encode('utf-8').sub(/^\[#{progname}\] /, '')
-        rescue Encoding::InvalidByteSequenceError
-          newline = line
+          level, line = line_level(newline)
+        rescue ArgumentError, Encoding::InvalidByteSequenceError => e
+          YleTf::Logger.warn "Caught exception #{e} with #{line}"
         end
-        level, line = line_level(newline)
 
         YleTf::Logger.public_send(level, progname) { line }
       end

--- a/lib/yle_tf/system/tf_hook_output_logger.rb
+++ b/lib/yle_tf/system/tf_hook_output_logger.rb
@@ -13,9 +13,9 @@ class YleTf
       def log(progname, line)
         # Remove `[<progname>] ` prefix from the output line.
         # This is mostly for backwards compatibility in Yle.
-        level = "INFO"
+        level = "INFO".downcase.to_sym
         begin
-          newline = line.encode('utf-8').sub(/^\[#{progname}\] /, '')
+          newline = line.encode(Encoding::UTF_8).sub(/^\[#{progname}\] /, '')
           level, line = line_level(newline)
         rescue ArgumentError, Encoding::InvalidByteSequenceError => e
           YleTf::Logger.warn "Caught exception #{e} with #{line}"


### PR DESCRIPTION
When we get output from terraform hook, the problem is that content is labeled as US-ASCII and String.encode won't solve that one. However, String.force_encoding will let ruby know that content is in UTF-8, even if it has originally assumed that it is something ele.
Rescue tries to guarantee that our deployment won't suffer complete failure in post-hook phase.